### PR TITLE
13-comments-list-api

### DIFF
--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -104,3 +104,34 @@ class CommentApiTests(TestCase):
         self.assertEqual(comment.created_at, before_created_at)
         self.assertNotEqual(comment.created_at, now)
         self.assertNotEqual(comment.updated_at, before_updated_at)
+
+    def test_list(self):
+        # 必须带 tweet_id
+        response = self.anonymous_client.get(COMMENT_URL)
+        self.assertEqual(response.status_code, 400)
+
+        # 带了 tweet_id 可以访问
+        # 一开始没有评论
+        response = self.anonymous_client.get(COMMENT_URL, {
+            'tweet_id': self.tweet.id,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['comments']), 0)
+
+        # 评论按照时间顺序排序
+        self.create_comment(self.linghu, self.tweet, '1')
+        self.create_comment(self.dongxie, self.tweet, '2')
+        self.create_comment(self.dongxie, self.create_tweet(self.dongxie), '3')
+        response = self.anonymous_client.get(COMMENT_URL, {
+            'tweet_id': self.tweet.id,
+        })
+        self.assertEqual(len(response.data['comments']), 2)
+        self.assertEqual(response.data['comments'][0]['content'], '1')
+        self.assertEqual(response.data['comments'][1]['content'], '2')
+
+        # 同时提供 user_id 和 tweet_id 只有 tweet_id 会在 filter 中生效
+        response = self.anonymous_client.get(COMMENT_URL, {
+            'tweet_id': self.tweet.id,
+            'user_id': self.linghu.id,
+        })
+        self.assertEqual(len(response.data['comments']), 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==4.1.3
 mysqlclient==2.1.1
 djangorestframework==3.14.0
+django-filter==22.1

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
 
     # third party
     'rest_framework',
+    'django_filters',
 
     # project apps
     'accounts',
@@ -51,7 +52,10 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 10
+    'PAGE_SIZE': 10,
+    'DEFAULT_FILTER_BACKENDS': [
+        'django_filters.rest_framework.DjangoFilterBackend',
+    ],
 }
 
 MIDDLEWARE = [
@@ -134,6 +138,11 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 
 STATIC_URL = 'static/'
+
+try:
+    from .local_settings import *
+except:
+    pass
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field


### PR DESCRIPTION
1. No need to do migrations as no model changes
2. At ubuntu server terminal, in project folder (with virtual env activated), run 'pip install -r requirements.txt' to install updated requirements(django-filter==22.1)
3. At ubuntu server terminal, in project folder (with virtual env activated), run 'python manage.py test -v3' to verify all 16 cases OK
4. Go to http://192.168.64.34:8000/api/comments/?tweet_id=10 (You may have a different tweet_id) to list all comments for tweet_id 10
<img width="420" alt="Screenshot 2022-11-27 at 3 01 11 AM" src="https://user-images.githubusercontent.com/3407579/204131785-5a374f14-460b-4062-8c34-d431c87ff964.png">
5. try another tweet_id without comments: http://192.168.64.34:8000/api/comments/?tweet_id=8
<img width="414" alt="Screenshot 2022-11-27 at 3 02 28 AM" src="https://user-images.githubusercontent.com/3407579/204131830-c2e6d4ea-b6ac-4d11-9d6a-35d2e86723ad.png">
6. Try a tweet_id that doesn't even exist in table: http://192.168.64.34:8000/api/comments/?tweet_id=15
<img width="614" alt="Screenshot 2022-11-27 at 3 03 34 AM" src="https://user-images.githubusercontent.com/3407579/204131863-4e88113e-65de-4f22-b908-1cabb9953850.png">