### PR TITLE
14-tweet-retrieve-api-with-comments

### DIFF
--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -8,6 +8,7 @@ from comments.models import Comment
 from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
+from utils.decorators import required_params
 
 
 class CommentViewSet(viewsets.GenericViewSet):
@@ -28,15 +29,8 @@ class CommentViewSet(viewsets.GenericViewSet):
             return [IsAuthenticated(), IsObjectOwner()]
         return [AllowAny()]
 
+    @required_params(params=['tweet_id'])
     def list(self, request, *args, **kwargs):
-        if 'tweet_id' not in request.query_params:
-            return Response(
-                {
-                    'message': 'missing tweet_id in request',
-                    'success': False,
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
         queryset = self.get_queryset()
         comments = self.filter_queryset(queryset).order_by('created_at')
         serializer = CommentSerializer(comments, many=True)

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,4 +1,5 @@
 from accounts.api.serializers import UserSerializer
+from comments.api.serializers import CommentSerializer
 from rest_framework import serializers
 from tweets.models import Tweet
 
@@ -23,3 +24,13 @@ class TweetCreateSerializer(serializers.ModelSerializer):
         content = validated_data['content']
         tweet = Tweet.objects.create(user=user, content=content)
         return tweet
+
+
+class TweetSerializerWithComments(serializers.ModelSerializer):
+    user = UserSerializer()
+    # <HOMEWORK> 使用 serialziers.SerializerMethodField 的方式实现 comments
+    comments = CommentSerializer(source='comment_set', many=True)
+
+    class Meta:
+        model = Tweet
+        fields = ('id', 'user', 'comments', 'created_at', 'content')

--- a/tweets/api/tests.py
+++ b/tweets/api/tests.py
@@ -6,6 +6,7 @@ from tweets.models import Tweet
 # 注意要加 '/' 结尾，要不然会产生 301 redirect
 TWEET_LIST_API = '/api/tweets/'
 TWEET_CREATE_API = '/api/tweets/'
+TWEET_RETRIEVE_API = '/api/tweets/{}/'
 
 
 class TweetApiTests(TestCase):
@@ -65,3 +66,21 @@ class TweetApiTests(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['user']['id'], self.user1.id)
         self.assertEqual(Tweet.objects.count(), tweets_count + 1)
+
+    def test_retrieve(self):
+        # tweet with id=-1 does not exist
+        url = TWEET_RETRIEVE_API.format(-1)
+        response = self.anonymous_client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+        # 获取某个 tweet 的时候会一起把 comments 也拿下
+        tweet = self.create_tweet(self.user1)
+        url = TWEET_RETRIEVE_API.format(tweet.id)
+        response = self.anonymous_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['comments']), 0)
+
+        self.create_comment(self.user2, tweet, 'holly s***')
+        self.create_comment(self.user1, tweet, 'hmm...')
+        response = self.anonymous_client.get(url)
+        self.assertEqual(len(response.data['comments']), 2)

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -1,9 +1,14 @@
+from newsfeeds.services import NewsFeedService
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
-from tweets.api.serializers import TweetSerializer, TweetCreateSerializer
+from tweets.api.serializers import (
+    TweetCreateSerializer,
+    TweetSerializer,
+    TweetSerializerWithComments,
+)
 from tweets.models import Tweet
-from newsfeeds.services import NewsFeedService
+from utils.decorators import required_params
 
 
 class TweetViewSet(viewsets.GenericViewSet,
@@ -16,17 +21,18 @@ class TweetViewSet(viewsets.GenericViewSet,
     serializer_class = TweetCreateSerializer
 
     def get_permissions(self):
-        if self.action == 'list':
+        if self.action in ['list', 'retrieve']:
             return [AllowAny()]
         return [IsAuthenticated()]
 
-    def list(self, request, *args, **kwargs):
-        """
-        重载 list 方法，不列出所有 tweets，必须要求指定 user_id 作为筛选条件
-        """
-        if 'user_id' not in request.query_params:
-            return Response('missing user_id', status=400)
+    def retrieve(self, request, *args, **kwargs):
+        # <HOMEWORK 1> 通过某个 query 参数 with_all_comments 来决定是否需要带上所有 comments
+        # <HOMEWORK 2> 通过某个 query 参数 with_preview_comments 来决定是否需要带上前三条 comments
+        tweet = self.get_object()
+        return Response(TweetSerializerWithComments(tweet).data)
 
+    @required_params(params=['user_id'])
+    def list(self, request, *args, **kwargs):
         # 这句查询会被翻译为
         # select * from twitter_tweets
         # where user_id = xxx

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,0 +1,40 @@
+from rest_framework.response import Response
+from rest_framework import status
+from functools import wraps
+
+
+def required_params(request_attr='query_params', params=None):
+    """
+    当我们使用 @required_params(params=['some_param']) 的时候
+    这个 required_params 函数应该需要返回一个 decorator 函数，这个 decorator 函数的参数
+    就是被 @required_params 包裹起来的函数 view_func
+    """
+
+    # 从效果上来说，参数中写 params=[] 很多时候也没有太大问题
+    # 但是从好的编程习惯上来说，函数的参数列表中的值不能是一个 mutable 的参数
+    if params is None:
+        params = []
+
+    def decorator(view_func):
+        """
+        decorator 函数通过 wraps 来将 view_func 里的参数解析出来传递给 _wrapped_view
+        这里的 instance 参数其实就是在 view_func 里的 self
+        """
+        @wraps(view_func)
+        def _wrapped_view(instance, request, *args, **kwargs):
+            data = getattr(request, request_attr)
+            missing_params = [
+                param
+                for param in params
+                if param not in data
+            ]
+            if missing_params:
+                params_str = ','.join(missing_params)
+                return Response({
+                    'message': u'missing {} in request'.format(params_str),
+                    'success': False,
+                }, status=status.HTTP_400_BAD_REQUEST)
+            # 做完检测之后，再去调用被 @required_params 包裹起来的 view_func
+            return view_func(instance, request, *args, **kwargs)
+        return _wrapped_view
+    return decorator


### PR DESCRIPTION
1. No need to do migrations as no model changes
2. At ubuntu server terminal, in project folder (with virtual env activated), run 'python manage.py test -v3' to verify all **17** cases OK
3. Go to http://192.168.64.34:8000/api/tweets/10/ (Your tweet ID will likely be different) to see tweet with comments
<img width="429" alt="Screenshot 2022-11-27 at 3 27 36 AM" src="https://user-images.githubusercontent.com/3407579/204132784-d27df4a0-2bed-4a19-a9c5-69b78b90743c.png">
4. Go to a tweet without comments: http://192.168.64.34:8000/api/tweets/1/ you can see comments as an empty list in the json response
<img width="363" alt="Screenshot 2022-11-27 at 3 28 41 AM" src="https://user-images.githubusercontent.com/3407579/204132839-5d7a3c8f-7b89-46ac-9a18-f3c9443f84e7.png">
