### PR TITLE
17-likes-cancel-api

### DIFF
--- a/likes/api/serializers.py
+++ b/likes/api/serializers.py
@@ -15,7 +15,7 @@ class LikeSerializer(serializers.ModelSerializer):
         fields = ('user', 'created_at')
 
 
-class LikeSerializerForCreate(serializers.ModelSerializer):
+class BaseLikeSerializerForCreateAndCancel(serializers.ModelSerializer):
     content_type = serializers.ChoiceField(choices=['comment', 'tweet'])
     object_id = serializers.IntegerField()
 
@@ -39,6 +39,9 @@ class LikeSerializerForCreate(serializers.ModelSerializer):
             raise ValidationError({'object_id': 'Object does not exist'})
         return data
 
+
+class LikeSerializerForCreate(BaseLikeSerializerForCreateAndCancel):
+
     def create(self, validated_data):
         model_class = self._get_model_class(validated_data)
         instance, _ = Like.objects.get_or_create(
@@ -47,3 +50,18 @@ class LikeSerializerForCreate(serializers.ModelSerializer):
             user=self.context['request'].user,
         )
         return instance
+
+
+class LikeSerializerForCancel(BaseLikeSerializerForCreateAndCancel):
+
+    def cancel(self):
+        """
+        cancel 方法是一个自定义的方法，cancel 不会被 serializer.save 调用
+        所以需要直接调用 serializer.cancel()
+        """
+        model_class = self._get_model_class(self.validated_data)
+        Like.objects.filter(
+            content_type=ContentType.objects.get_for_model(model_class),
+            object_id=self.validated_data['object_id'],
+            user=self.context['request'].user,
+        ).delete()

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -2,6 +2,7 @@ from testing.testcases import TestCase
 
 
 LIKE_BASE_URL = '/api/likes/'
+LIKE_CANCEL_URL = '/api/likes/cancel/'
 
 
 class LikeApiTests(TestCase):
@@ -73,3 +74,59 @@ class LikeApiTests(TestCase):
         self.assertEqual(comment.like_set.count(), 1)
         self.dongxie_client.post(LIKE_BASE_URL, data)
         self.assertEqual(comment.like_set.count(), 2)
+
+    def test_cancel(self):
+        tweet = self.create_tweet(self.linghu)
+        comment = self.create_comment(self.dongxie, tweet)
+        like_comment_data = {'content_type': 'comment', 'object_id': comment.id}
+        like_tweet_data = {'content_type': 'tweet', 'object_id': tweet.id}
+        self.linghu_client.post(LIKE_BASE_URL, like_comment_data)
+        self.dongxie_client.post(LIKE_BASE_URL, like_tweet_data)
+        self.assertEqual(tweet.like_set.count(), 1)
+        self.assertEqual(comment.like_set.count(), 1)
+
+        # login required
+        response = self.anonymous_client.post(LIKE_CANCEL_URL, like_comment_data)
+        self.assertEqual(response.status_code, 403)
+
+        # get is not allowed
+        response = self.linghu_client.get(LIKE_CANCEL_URL, like_comment_data)
+        self.assertEqual(response.status_code, 405)
+
+        # wrong content_type
+        response = self.linghu_client.post(LIKE_CANCEL_URL, {
+            'content_type': 'wrong',
+            'object_id': 1,
+        })
+        self.assertEqual(response.status_code, 400)
+
+        # wrong object_id
+        response = self.linghu_client.post(LIKE_CANCEL_URL, {
+            'content_type': 'comment',
+            'object_id': -1,
+        })
+        self.assertEqual(response.status_code, 400)
+
+        # dongxie has not liked before
+        response = self.dongxie_client.post(LIKE_CANCEL_URL, like_comment_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(tweet.like_set.count(), 1)
+        self.assertEqual(comment.like_set.count(), 1)
+
+        # successfully canceled
+        response = self.linghu_client.post(LIKE_CANCEL_URL, like_comment_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(tweet.like_set.count(), 1)
+        self.assertEqual(comment.like_set.count(), 0)
+
+        # linghu has not liked before
+        response = self.linghu_client.post(LIKE_CANCEL_URL, like_tweet_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(tweet.like_set.count(), 1)
+        self.assertEqual(comment.like_set.count(), 0)
+
+        # dongxie's like has been canceled
+        response = self.dongxie_client.post(LIKE_CANCEL_URL, like_tweet_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(tweet.like_set.count(), 0)
+        self.assertEqual(comment.like_set.count(), 0)

--- a/likes/api/views.py
+++ b/likes/api/views.py
@@ -1,9 +1,11 @@
 from likes.api.serializers import (
     LikeSerializer,
+    LikeSerializerForCancel,
     LikeSerializerForCreate,
 )
 from likes.models import Like
 from rest_framework import viewsets, status
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from utils.decorators import required_params
@@ -30,3 +32,18 @@ class LikeViewSet(viewsets.GenericViewSet):
             LikeSerializer(instance).data,
             status=status.HTTP_201_CREATED,
         )
+
+    @action(methods=['POST'], detail=False)
+    @required_params(request_attr='data', params=['content_type', 'object_id'])
+    def cancel(self, request, *args, **kwargs):
+        serializer = LikeSerializerForCancel(
+            data=request.data,
+            context={'request': request},
+        )
+        if not serializer.is_valid():
+            return Response({
+                'message': 'Please check input',
+                'errors': serializer.errors,
+            }, status=status.HTTP_400_BAD_REQUEST)
+        serializer.cancel()
+        return Response({'success': True}, status=status.HTTP_200_OK)


### PR DESCRIPTION
1. No migrations needed for this commit
2. At ubuntu terminal, with your virtual env activated, run 'python manage.py test -v3' to verify all **22 cases** completes successfully.
3. Go to http://192.168.64.34:8000/api/likes/cancel/ to test cancel likes
4. Before cancel, create more likes refer to https://github.com/byegates/twitter2/pull/45
5. Below are likes I created:
<img width="773" alt="Screenshot 2022-11-27 at 3 50 03 PM" src="https://user-images.githubusercontent.com/3407579/204166491-c84588de-c982-42a0-9d26-fd9ab5805e6a.png">
6. Cancel comment id 2 and tweet ID 1
<img width="621" alt="Screenshot 2022-11-27 at 3 49 48 PM" src="https://user-images.githubusercontent.com/3407579/204166515-3e3bd184-c6d7-426d-a000-0842dfd0270a.png">
7. You should see API response like below
<img width="259" alt="Screenshot 2022-11-27 at 3 49 53 PM" src="https://user-images.githubusercontent.com/3407579/204166541-cd7584d1-0e12-4c10-a4fd-dba1f79a45b1.png">
8. Check table, two rows for tweet id 1 and comment id 2 are deleted (likes canceled):
<img width="753" alt="Screenshot 2022-11-27 at 3 50 24 PM" src="https://user-images.githubusercontent.com/3407579/204166549-05cdf19e-4b8b-4477-a750-c190d29743df.png">

