### PR TITLE
18-inject-likes-info-to-other-apis

### DIFF
--- a/comments/api/serializers.py
+++ b/comments/api/serializers.py
@@ -1,5 +1,6 @@
 from accounts.api.serializers import UserSerializer
 from comments.models import Comment
+from likes.services import LikeService
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from tweets.models import Tweet
@@ -7,10 +8,27 @@ from tweets.models import Tweet
 
 class CommentSerializer(serializers.ModelSerializer):
     user = UserSerializer()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
-        fields = ('id', 'tweet_id', 'user', 'content', 'created_at')
+        fields = (
+            'id',
+            'tweet_id',
+            'user',
+            'content',
+            'created_at',
+            'likes_count',
+            'has_liked',
+        )
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
+
 
 
 class CommentSerializerForCreate(serializers.ModelSerializer):

--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -5,6 +5,9 @@ from testing.testcases import TestCase
 
 
 COMMENT_URL = '/api/comments/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 
 class CommentApiTests(TestCase):
@@ -135,3 +138,24 @@ class CommentApiTests(TestCase):
             'user_id': self.linghu.id,
         })
         self.assertEqual(len(response.data['comments']), 2)
+
+    def test_comments_count(self):
+        # test tweet detail api
+        tweet = self.create_tweet(self.linghu)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments_count'], 0)
+
+        # test tweet list api
+        self.create_comment(self.linghu, tweet)
+        response = self.dongxie_client.get(TWEET_LIST_API, {'user_id': self.linghu.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['tweets'][0]['comments_count'], 1)
+
+        # test newsfeeds list api
+        self.create_comment(self.dongxie, tweet)
+        self.create_newsfeed(self.dongxie, tweet)
+        response = self.dongxie_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['comments_count'], 2)

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -33,7 +33,11 @@ class CommentViewSet(viewsets.GenericViewSet):
     def list(self, request, *args, **kwargs):
         queryset = self.get_queryset()
         comments = self.filter_queryset(queryset).order_by('created_at')
-        serializer = CommentSerializer(comments, many=True)
+        serializer = CommentSerializer(
+            comments,
+            context={'request': request},
+            many=True,
+        )
         return Response(
             {'comments': serializer.data},
             status=status.HTTP_200_OK,
@@ -57,7 +61,7 @@ class CommentViewSet(viewsets.GenericViewSet):
         # save 方法会触发 serializer 里的 create 方法，点进 save 的具体实现里可以看到
         comment = serializer.save()
         return Response(
-            CommentSerializer(comment).data,
+            CommentSerializer(comment, context={'request': request}).data,
             status=status.HTTP_201_CREATED,
         )
 
@@ -76,7 +80,7 @@ class CommentViewSet(viewsets.GenericViewSet):
         # save 是根据 instance 参数有没有传来决定是触发 create 还是 update
         comment = serializer.save()
         return Response(
-            CommentSerializer(comment).data,
+            CommentSerializer(comment, context={'request': request}).data,
             status=status.HTTP_200_OK,
         )
 

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -1,8 +1,13 @@
 from testing.testcases import TestCase
+from rest_framework.test import APIClient
 
 
 LIKE_BASE_URL = '/api/likes/'
 LIKE_CANCEL_URL = '/api/likes/cancel/'
+COMMENT_LIST_API = '/api/comments/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 
 class LikeApiTests(TestCase):
@@ -130,3 +135,67 @@ class LikeApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(tweet.like_set.count(), 0)
         self.assertEqual(comment.like_set.count(), 0)
+
+    def test_likes_in_comments_api(self):
+        tweet = self.create_tweet(self.linghu)
+        comment = self.create_comment(self.linghu, tweet)
+
+        # test anonymous
+        anonymous_client = APIClient()
+        response = anonymous_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+
+        # test comments list api
+        response = self.dongxie_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+        self.create_like(self.dongxie, comment)
+        response = self.dongxie_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 1)
+
+        # test tweet detail api
+        self.create_like(self.linghu, comment)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 2)
+
+    def test_likes_in_tweets_api(self):
+        tweet = self.create_tweet(self.linghu)
+
+        # test tweet detail api
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['has_liked'], False)
+        self.assertEqual(response.data['likes_count'], 0)
+        self.create_like(self.dongxie, tweet)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(response.data['has_liked'], True)
+        self.assertEqual(response.data['likes_count'], 1)
+
+        # test tweets list api
+        response = self.dongxie_client.get(TWEET_LIST_API, {'user_id': self.linghu.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['tweets'][0]['has_liked'], True)
+        self.assertEqual(response.data['tweets'][0]['likes_count'], 1)
+
+        # test newsfeeds list api
+        self.create_like(self.linghu, tweet)
+        self.create_newsfeed(self.dongxie, tweet)
+        response = self.dongxie_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['has_liked'], True)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['likes_count'], 2)
+
+        # test likes details
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(len(response.data['likes']), 2)
+        self.assertEqual(response.data['likes'][0]['user']['id'], self.linghu.id)
+        self.assertEqual(response.data['likes'][1]['user']['id'], self.dongxie.id)

--- a/likes/services.py
+++ b/likes/services.py
@@ -1,0 +1,15 @@
+from likes.models import Like
+from django.contrib.contenttypes.models import ContentType
+
+
+class LikeService(object):
+
+    @classmethod
+    def has_liked(cls, user, target):
+        if user.is_anonymous:
+            return False
+        return Like.objects.filter(
+            content_type=ContentType.objects.get_for_model(target.__class__),
+            object_id=target.id,
+            user=user,
+        ).exists()

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -17,7 +17,11 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         return NewsFeed.objects.filter(user=self.request.user)
 
     def list(self, request):
-        serializer = NewsFeedSerializer(self.get_queryset(), many=True)
+        serializer = NewsFeedSerializer(
+            self.get_queryset(),
+            context={'request': request},
+            many=True,
+        )
         return Response({
             'newsfeeds': serializer.data,
         }, status=status.HTTP_200_OK)

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase as DjangoTestCase
 from likes.models import Like
+from newsfeeds.models import NewsFeed
 from rest_framework.test import APIClient
 from tweets.models import Tweet
 
@@ -29,6 +30,9 @@ class TestCase(DjangoTestCase):
         if content is None:
             content = 'default tweet content'
         return Tweet.objects.create(user=user, content=content)
+
+    def create_newsfeed(self, user, tweet):
+        return NewsFeed.objects.create(user=user, tweet=tweet)
 
     def create_comment(self, user, tweet, content=None):
         if content is None:

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,18 +1,40 @@
 from accounts.api.serializers import UserSerializer
 from comments.api.serializers import CommentSerializer
+from likes.api.serializers import LikeSerializer
+from likes.services import LikeService
 from rest_framework import serializers
 from tweets.models import Tweet
 
 
 class TweetSerializer(serializers.ModelSerializer):
     user = UserSerializer()
+    comments_count = serializers.SerializerMethodField()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'created_at', 'content')
+        fields = (
+            'id',
+            'user',
+            'created_at',
+            'content',
+            'comments_count',
+            'likes_count',
+            'has_liked',
+        )
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+
+    def get_comments_count(self, obj):
+        return obj.comment_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
 
 
-class TweetCreateSerializer(serializers.ModelSerializer):
+class TweetSerializerForCreate(serializers.ModelSerializer):
     content = serializers.CharField(min_length=6, max_length=140)
 
     class Meta:
@@ -26,11 +48,21 @@ class TweetCreateSerializer(serializers.ModelSerializer):
         return tweet
 
 
-class TweetSerializerWithComments(serializers.ModelSerializer):
-    user = UserSerializer()
-    # <HOMEWORK> 使用 serialziers.SerializerMethodField 的方式实现 comments
+class TweetSerializerForDetail(TweetSerializer):
     comments = CommentSerializer(source='comment_set', many=True)
+    likes = LikeSerializer(source='like_set', many=True)
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'comments', 'created_at', 'content')
+        fields = (
+            'id',
+            'user',
+            'comments',
+            'created_at',
+            'content',
+            'likes',
+            'comments',
+            'likes_count',
+            'comments_count',
+            'has_liked',
+        )

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -3,9 +3,9 @@ from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from tweets.api.serializers import (
-    TweetCreateSerializer,
     TweetSerializer,
-    TweetSerializerWithComments,
+    TweetSerializerForCreate,
+    TweetSerializerForDetail,
 )
 from tweets.models import Tweet
 from utils.decorators import required_params
@@ -18,7 +18,7 @@ class TweetViewSet(viewsets.GenericViewSet,
     API endpoint that allows users to create, list tweets
     """
     queryset = Tweet.objects.all()
-    serializer_class = TweetCreateSerializer
+    serializer_class = TweetSerializerForCreate
 
     def get_permissions(self):
         if self.action in ['list', 'retrieve']:
@@ -28,8 +28,11 @@ class TweetViewSet(viewsets.GenericViewSet,
     def retrieve(self, request, *args, **kwargs):
         # <HOMEWORK 1> 通过某个 query 参数 with_all_comments 来决定是否需要带上所有 comments
         # <HOMEWORK 2> 通过某个 query 参数 with_preview_comments 来决定是否需要带上前三条 comments
-        tweet = self.get_object()
-        return Response(TweetSerializerWithComments(tweet).data)
+        serializer = TweetSerializerForDetail(
+            self.get_object(),
+            context={'request': request},
+        )
+        return Response(serializer.data)
 
     @required_params(params=['user_id'])
     def list(self, request, *args, **kwargs):
@@ -42,7 +45,11 @@ class TweetViewSet(viewsets.GenericViewSet,
         tweets = Tweet.objects.filter(
             user_id=request.query_params['user_id']
         ).order_by('-created_at')
-        serializer = TweetSerializer(tweets, many=True)
+        serializer = TweetSerializer(
+            tweets,
+            context={'request': request},
+            many=True,
+        )
         # 一般来说 json 格式的 response 默认都要用 hash 的格式
         # 而不能用 list 的格式（约定俗成）
         return Response({'tweets': serializer.data})
@@ -51,7 +58,7 @@ class TweetViewSet(viewsets.GenericViewSet,
         """
         重载 create 方法，因为需要默认用当前登录用户作为 tweet.user
         """
-        serializer = TweetCreateSerializer(
+        serializer = TweetSerializerForCreate(
             data=request.data,
             context={'request': request},
         )
@@ -63,4 +70,5 @@ class TweetViewSet(viewsets.GenericViewSet,
             }, status=400)
         tweet = serializer.save()
         NewsFeedService.fanout_to_followers(tweet)
-        return Response(TweetSerializer(tweet).data, status=201)
+        serializer = TweetSerializer(tweet, context={'request': request})
+        return Response(serializer.data, status=201)


### PR DESCRIPTION
1. No migrations for this commit
2. At ubuntu terminal, with virtual env activated, run 'python manage.py test -v3' to verify all **25 cases** pass
3. Create multiple tweets, comments, and like them a few times. (You need a few users to do so)
4. go to: http://192.168.64.34:8000/api/newsfeeds/ to check like counts and comment counts implemented as part of this commit like below
<img width="367" alt="Screenshot 2022-11-27 at 4 31 07 PM" src="https://user-images.githubusercontent.com/3407579/204168969-fa6b5dd9-2c25-4f38-b3fe-094ddf09aaec.png">
5. Got to tweet list of user id 3 (you may have different id): http://192.168.64.34:8000/api/tweets/?user_id=3, we can now see comment counts and like counts for each tweet of user 3:
<img width="373" alt="Screenshot 2022-11-27 at 4 31 36 PM" src="https://user-images.githubusercontent.com/3407579/204169024-74ac0d93-369f-4d12-9520-78cea5d02c15.png">
6. Go to comment list of tweet id 13 (you may have a different tweet id) http://192.168.64.34:8000/api/tweets/13/, you can now see all comments as a list of tweet id 3, and the likes count for each comment
<img width="433" alt="Screenshot 2022-11-27 at 4 33 06 PM" src="https://user-images.githubusercontent.com/3407579/204169104-08ae03dd-5532-4001-b696-3e7217c1ed85.png">
7. Go to tweet id 13, it tells you content of the tweet itself, detail of all comments (it's content and likes count) of this tweet, likes and comments count, all the likes of this tweet (with each specific user who liked and the timestamp etc.)
<img width="285" alt="Screenshot 2022-11-27 at 4 41 11 PM" src="https://user-images.githubusercontent.com/3407579/204169228-1812a344-e16d-4f07-90b6-f53845feb16f.png">
