### PR TITLE
20-notifications-api-part-1

### DIFF
--- a/inbox/api/serializers.py
+++ b/inbox/api/serializers.py
@@ -1,0 +1,20 @@
+from rest_framework import serializers
+from notifications.models import Notification
+
+
+class NotificationSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Notification
+        fields = (
+            'id',
+            'actor_content_type',
+            'actor_object_id',
+            'verb',
+            'action_object_content_type',
+            'action_object_object_id',
+            'target_content_type',
+            'target_object_id',
+            'timestamp',
+            'unread',
+        )

--- a/inbox/api/tests.py
+++ b/inbox/api/tests.py
@@ -1,9 +1,9 @@
 from notifications.models import Notification
 from testing.testcases import TestCase
 
-
 COMMENT_URL = '/api/comments/'
 LIKE_URL = '/api/likes/'
+NOTIFICATION_URL = '/api/notifications/'
 
 
 class NotificationTests(TestCase):
@@ -28,3 +28,87 @@ class NotificationTests(TestCase):
             'object_id': self.dongxie_tweet.id,
         })
         self.assertEqual(Notification.objects.count(), 1)
+
+
+class NotificationApiTests(TestCase):
+
+    def setUp(self):
+        self.linghu, self.linghu_client = self.create_user_and_client('linghu')
+        self.dongxie, self.dongxie_client = self.create_user_and_client('dongxie')
+        self.linghu_tweet = self.create_tweet(self.linghu)
+
+    def test_unread_count(self):
+        self.dongxie_client.post(LIKE_URL, {
+            'content_type': 'tweet',
+            'object_id': self.linghu_tweet.id,
+        })
+
+        url = '/api/notifications/unread-count/'
+        response = self.linghu_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['unread_count'], 1)
+
+        comment = self.create_comment(self.linghu, self.linghu_tweet)
+        self.dongxie_client.post(LIKE_URL, {
+            'content_type': 'comment',
+            'object_id': comment.id,
+        })
+        response = self.linghu_client.get(url)
+        self.assertEqual(response.data['unread_count'], 2)
+
+    def test_mark_all_as_read(self):
+        self.dongxie_client.post(LIKE_URL, {
+            'content_type': 'tweet',
+            'object_id': self.linghu_tweet.id,
+        })
+        comment = self.create_comment(self.linghu, self.linghu_tweet)
+        self.dongxie_client.post(LIKE_URL, {
+            'content_type': 'comment',
+            'object_id': comment.id,
+        })
+
+        unread_url = '/api/notifications/unread-count/'
+        response = self.linghu_client.get(unread_url)
+        self.assertEqual(response.data['unread_count'], 2)
+
+        mark_url = '/api/notifications/mark-all-as-read/'
+        response = self.linghu_client.get(mark_url)
+        self.assertEqual(response.status_code, 405)
+        response = self.linghu_client.post(mark_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['marked_count'], 2)
+        response = self.linghu_client.get(unread_url)
+        self.assertEqual(response.data['unread_count'], 0)
+
+    def test_list(self):
+        self.dongxie_client.post(LIKE_URL, {
+            'content_type': 'tweet',
+            'object_id': self.linghu_tweet.id,
+        })
+        comment = self.create_comment(self.linghu, self.linghu_tweet)
+        self.dongxie_client.post(LIKE_URL, {
+            'content_type': 'comment',
+            'object_id': comment.id,
+        })
+
+        # 匿名用户无法访问 api
+        response = self.anonymous_client.get(NOTIFICATION_URL)
+        self.assertEqual(response.status_code, 403)
+        # dongxie 看不到任何 notifications
+        response = self.dongxie_client.get(NOTIFICATION_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['count'], 0)
+        # linghu 看到两个 notifications
+        response = self.linghu_client.get(NOTIFICATION_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['count'], 2)
+        # 标记之后看到一个未读
+        notification = self.linghu.notifications.first()
+        notification.unread = False
+        notification.save()
+        response = self.linghu_client.get(NOTIFICATION_URL)
+        self.assertEqual(response.data['count'], 2)
+        response = self.linghu_client.get(NOTIFICATION_URL, {'unread': True})
+        self.assertEqual(response.data['count'], 1)
+        response = self.linghu_client.get(NOTIFICATION_URL, {'unread': False})
+        self.assertEqual(response.data['count'], 1)

--- a/inbox/api/views.py
+++ b/inbox/api/views.py
@@ -1,0 +1,28 @@
+from django_filters.rest_framework import DjangoFilterBackend
+from inbox.api.serializers import NotificationSerializer
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+
+class NotificationViewSet(
+    viewsets.GenericViewSet,
+    viewsets.mixins.ListModelMixin,
+):
+    serializer_class = NotificationSerializer
+    permission_classes = (IsAuthenticated,)
+    filterset_fields = ('unread',)
+
+    def get_queryset(self):
+        return self.request.user.notifications.all()
+
+    @action(methods=['GET'], detail=False, url_path='unread-count')
+    def unread_count(self, request, *args, **kwargs):
+        count = self.get_queryset().filter(unread=True).count()
+        return Response({'unread_count': count}, status=status.HTTP_200_OK)
+
+    @action(methods=['POST'], detail=False, url_path='mark-all-as-read')
+    def mark_all_as_read(self, request, *args, **kwargs):
+        updated_count = self.get_queryset().update(unread=False)
+        return Response({'marked_count': updated_count}, status=status.HTTP_200_OK)

--- a/twitter/urls.py
+++ b/twitter/urls.py
@@ -20,6 +20,7 @@ from rest_framework import routers
 from accounts.api.views import UserViewSet, AccountViewSet
 from comments.api.views import CommentViewSet
 from friendships.api.views import FriendshipViewSet
+from inbox.api.views import NotificationViewSet
 from likes.api.views import LikeViewSet
 from newsfeeds.api.views import NewsFeedViewSet
 from tweets.api.views import TweetViewSet
@@ -32,6 +33,7 @@ router.register(r'api/friendships', FriendshipViewSet, basename='friendships')
 router.register(r'api/newsfeeds', NewsFeedViewSet, basename='newsfeeds')
 router.register(r'api/comments', CommentViewSet, basename='comments')
 router.register(r'api/likes', LikeViewSet, basename='likes')
+router.register(r'api/notifications', NotificationViewSet, basename='notifications')
 
 urlpatterns = [
     path('admin/', admin.site.urls),


### PR DESCRIPTION
1. At ubuntu terminal, with your python virtual env activated, run 'python manage.py test -v3', you should see all **32 tests** pass.
2. Go to http://192.168.64.34:8000/api/notifications/ to check your notifications
Empty notification inbox
<img width="213" alt="Screenshot 2022-11-27 at 6 32 10 PM" src="https://user-images.githubusercontent.com/3407579/204178979-1cac5f36-a44d-46ec-827d-a828e619f695.png">
notification inbox with unread counts
<img width="414" alt="Screenshot 2022-11-27 at 6 32 30 PM" src="https://user-images.githubusercontent.com/3407579/204179015-df6eb1d5-bae1-47e9-8fb1-97c097334d56.png">
3. Click unread count under options
<img width="336" alt="Screenshot 2022-11-27 at 6 33 03 PM" src="https://user-images.githubusercontent.com/3407579/204179083-1c1edc3c-16e5-4e94-aeb4-611ff665f2b6.png">
<img width="286" alt="Screenshot 2022-11-27 at 6 33 27 PM" src="https://user-images.githubusercontent.com/3407579/204179141-df2c3e5d-4a1b-48da-a593-8ff8dd7c1cca.png">
You could also use: http://192.168.64.34:8000/api/notifications/unread-count/
4. Use filter
<img width="153" alt="Screenshot 2022-11-27 at 6 34 49 PM" src="https://user-images.githubusercontent.com/3407579/204179294-1129e971-d571-4b36-9fb5-c073ce39e29f.png">
Could also use: http://192.168.64.34:8000/api/notifications/?unread=false
<img width="289" alt="Screenshot 2022-11-27 at 6 35 02 PM" src="https://user-images.githubusercontent.com/3407579/204179322-7d109d92-528a-4aef-97ac-72dd09b41f31.png">
5. Go to http://192.168.64.34:8000/api/notifications/mark-all-as-read/ :
<img width="372" alt="Screenshot 2022-11-27 at 6 35 24 PM" src="https://user-images.githubusercontent.com/3407579/204179379-f855bfe2-76c6-41b5-afe3-ea765921c176.png">
Ignore everything else, just click post:
<img width="483" alt="Screenshot 2022-11-27 at 6 38 45 PM" src="https://user-images.githubusercontent.com/3407579/204179888-82d680da-e7c4-4fad-b20c-341ba41da33f.png">
Now you see marked all (2) unread count:
<img width="255" alt="Screenshot 2022-11-27 at 6 39 09 PM" src="https://user-images.githubusercontent.com/3407579/204179935-d37a18f4-5af8-49d2-87a8-52ffeae533ab.png">
Go back to check unread count is now 0:
<img width="228" alt="Screenshot 2022-11-27 at 6 39 26 PM" src="https://user-images.githubusercontent.com/3407579/204179974-de2bc662-05d1-4221-8d24-649956c9d68f.png">
Read notification now has 2 messages ( http://192.168.64.34:8000/api/notifications/?unread=false ) :  
<img width="377" alt="Screenshot 2022-11-27 at 6 41 05 PM" src="https://user-images.githubusercontent.com/3407579/204180023-54cf55bf-00e5-4bf2-8f4c-625dd5ce8118.png">
Unread now has 0 ( http://192.168.64.34:8000/api/notifications/?unread=true ):
<img width="259" alt="Screenshot 2022-11-27 at 6 42 01 PM" src="https://user-images.githubusercontent.com/3407579/204180118-9b9bbbac-cf5e-40c1-ae98-6fe5b4442d9e.png">