### PR TITLE
21-notifications-api-part-2

### DIFF
--- a/inbox/api/serializers.py
+++ b/inbox/api/serializers.py
@@ -18,3 +18,18 @@ class NotificationSerializer(serializers.ModelSerializer):
             'timestamp',
             'unread',
         )
+
+
+class NotificationSerializerForUpdate(serializers.ModelSerializer):
+    # BooleanField 会自动兼容 true, false, "true", "false", "True", "1", "0"
+    # 等情况，并都转换为 python 的 boolean 类型的 True / False
+    unread = serializers.BooleanField()
+
+    class Meta:
+        model = Notification
+        fields = ('unread',)
+
+    def update(self, instance, validated_data):
+        instance.unread = validated_data['unread']
+        instance.save()
+        return instance

--- a/inbox/api/tests.py
+++ b/inbox/api/tests.py
@@ -112,3 +112,45 @@ class NotificationApiTests(TestCase):
         self.assertEqual(response.data['count'], 1)
         response = self.linghu_client.get(NOTIFICATION_URL, {'unread': False})
         self.assertEqual(response.data['count'], 1)
+
+    def test_update(self):
+        self.dongxie_client.post(LIKE_URL, {
+            'content_type': 'tweet',
+            'object_id': self.linghu_tweet.id,
+        })
+        comment = self.create_comment(self.linghu, self.linghu_tweet)
+        self.dongxie_client.post(LIKE_URL, {
+            'content_type': 'comment',
+            'object_id': comment.id,
+        })
+        notification = self.linghu.notifications.first()
+
+        url = '/api/notifications/{}/'.format(notification.id)
+        # post 不行，需要用 put
+        response = self.dongxie_client.post(url, {'unread': False})
+        self.assertEqual(response.status_code, 405)
+        # 不可以被其他人改变 notification 状态
+        response = self.anonymous_client.put(url, {'unread': False})
+        self.assertEqual(response.status_code, 403)
+        # 因为 queryset 是按照当前登陆用户来，所以会返回 404 而不是 403
+        response = self.dongxie_client.put(url, {'unread': False})
+        self.assertEqual(response.status_code, 404)
+        # 成功标记为已读
+        response = self.linghu_client.put(url, {'unread': False})
+        self.assertEqual(response.status_code, 200)
+        unread_url = '/api/notifications/unread-count/'
+        response = self.linghu_client.get(unread_url)
+        self.assertEqual(response.data['unread_count'], 1)
+
+        # 再标记为未读
+        response = self.linghu_client.put(url, {'unread': True})
+        response = self.linghu_client.get(unread_url)
+        self.assertEqual(response.data['unread_count'], 2)
+        # 必须带 unread
+        response = self.linghu_client.put(url, {'verb': 'newverb'})
+        self.assertEqual(response.status_code, 400)
+        # 不可修改其他的信息
+        response = self.linghu_client.put(url, {'verb': 'newverb', 'unread': False})
+        self.assertEqual(response.status_code, 200)
+        notification.refresh_from_db()
+        self.assertNotEqual(notification.verb, 'newverb')

--- a/inbox/api/views.py
+++ b/inbox/api/views.py
@@ -1,9 +1,12 @@
-from django_filters.rest_framework import DjangoFilterBackend
-from inbox.api.serializers import NotificationSerializer
+from inbox.api.serializers import (
+    NotificationSerializer,
+    NotificationSerializerForUpdate,
+)
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from utils.decorators import required_params
 
 
 class NotificationViewSet(
@@ -26,3 +29,32 @@ class NotificationViewSet(
     def mark_all_as_read(self, request, *args, **kwargs):
         updated_count = self.get_queryset().update(unread=False)
         return Response({'marked_count': updated_count}, status=status.HTTP_200_OK)
+
+    @required_params(method='POST', params=['unread'])
+    def update(self, request, *args, **kwargs):
+        """
+        用户可以标记一个 notification 为已读或者未读。标记已读和未读都是对 notification
+        的一次更新操作，所以直接重载 update 的方法来实现。另外一种实现方法是用一个专属的 action：
+            @action(methods=['POST'], detail=True, url_path='mark-as-read')
+            def mark_as_read(self, request, *args, **kwargs):
+                ...
+            @action(methods=['POST'], detail=True, url_path='mark-as-unread')
+            def mark_as_unread(self, request, *args, **kwargs):
+                ...
+        两种方法都可以，我更偏好重载 update，因为更通用更 rest 一些, 而且 mark as unread 和
+        mark as read 可以公用一套逻辑。
+        """
+        serializer = NotificationSerializerForUpdate(
+            instance=self.get_object(),
+            data=request.data,
+        )
+        if not serializer.is_valid():
+            return Response({
+                'message': "Please check input",
+                'errors': serializer.errors,
+            }, status=status.HTTP_400_BAD_REQUEST)
+        notification = serializer.save()
+        return Response(
+            NotificationSerializer(notification).data,
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
1. No migrations for this commit
2. Run test to verify **33 test cases** are okay
3. Update a notification from read to unread (notification id 1 was marked as read as part of previous pull request test):
Go to: http://192.168.64.34:8000/api/notifications/1/
Check unread, and click put:
<img width="485" alt="Screenshot 2022-11-27 at 6 50 17 PM" src="https://user-images.githubusercontent.com/3407579/204181700-536b8e54-e885-47c1-aa97-de85189b1351.png">
Response, unread: true
<img width="327" alt="Screenshot 2022-11-27 at 6 50 33 PM" src="https://user-images.githubusercontent.com/3407579/204181829-e673c310-4f39-4b15-bd8f-90874dae6b9f.png">
check data base notifications_notifcation table, notification id 1 was marked as unread(1):
<img width="622" alt="Screenshot 2022-11-27 at 6 50 48 PM" src="https://user-images.githubusercontent.com/3407579/204181875-170e7c58-cc67-4a67-82e4-7e9b19bfb191.png">
4. Mark a notification from unread to read (from above table we can see id 3 is unread)
Go to: http://192.168.64.34:8000/api/notifications/3/ and click raw data, notice unread: false, click put:
<img width="514" alt="Screenshot 2022-11-27 at 6 52 23 PM" src="https://user-images.githubusercontent.com/3407579/204181988-8f848c29-8e8c-4451-b051-7dd214d6bc90.png">
notification id 3 set to read (unread:false) successfully
<img width="488" alt="Screenshot 2022-11-27 at 6 52 44 PM" src="https://user-images.githubusercontent.com/3407579/204182073-580e6046-5189-404b-ae50-b58247d2672f.png">
Check change in table:
<img width="625" alt="Screenshot 2022-11-27 at 6 53 00 PM" src="https://user-images.githubusercontent.com/3407579/204182109-d13fad1c-113e-4847-a169-60cfd0eb7b7c.png">

