### PR TITLE
26-friendships-pagination

### DIFF
--- a/friendships/api/paginations.py
+++ b/friendships/api/paginations.py
@@ -1,0 +1,22 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class FriendshipPagination(PageNumberPagination):
+    # 默认的 page size，也就是 page 没有在 url 参数里的时候
+    page_size = 20
+    # 默认的 page_size_query_param 是 None 表示不允许客户端指定每一页的大小
+    # 如果加上这个配置，就表示客户端可以通过 size=10 来指定一个特定的大小用于不同的场景
+    # 比如手机端和web端访问同一个API但是需要的 size 大小是不同的。
+    page_size_query_param = 'size'
+    # 允许客户端指定的最大 page_size 是多少
+    max_page_size = 20
+
+    def get_paginated_response(self, data):
+        return Response({
+            'total_results': self.page.paginator.count,
+            'total_pages': self.page.paginator.num_pages,
+            'page_number': self.page.number,
+            'has_next_page': self.page.has_next(),
+            'results': data,
+        })

--- a/friendships/api/serializers.py
+++ b/friendships/api/serializers.py
@@ -1,5 +1,6 @@
 from accounts.api.serializers import UserSerializerForFriendship
 from friendships.models import Friendship
+from friendships.services import FriendshipService
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -34,16 +35,33 @@ class FriendshipSerializerForCreate(serializers.ModelSerializer):
 class FollowerSerializer(serializers.ModelSerializer):
     user = UserSerializerForFriendship(source='from_user')
     created_at = serializers.DateTimeField()
+    has_followed = serializers.SerializerMethodField()
 
     class Meta:
         model = Friendship
-        fields = ('user', 'created_at')
+        fields = ('user', 'created_at', 'has_followed')
+
+    def get_has_followed(self, obj):
+        if self.context['request'].user.is_anonymous:
+            return False
+        # <TODO> 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
+        # 我们将在后序的课程中解决这个问题
+        return FriendshipService.has_followed(self.context['request'].user, obj.from_user)
 
 
 class FollowingSerializer(serializers.ModelSerializer):
     user = UserSerializerForFriendship(source='to_user')
     created_at = serializers.DateTimeField()
+    has_followed = serializers.SerializerMethodField()
 
     class Meta:
         model = Friendship
-        fields = ('user', 'created_at')
+        fields = ('user', 'created_at', 'has_followed')
+
+    def get_has_followed(self, obj):
+        if self.context['request'].user.is_anonymous:
+            return False
+
+        # <TODO> 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
+        # 我们将在后序的课程中解决这个问题
+        return FriendshipService.has_followed(self.context['request'].user, obj.to_user)

--- a/friendships/api/tests.py
+++ b/friendships/api/tests.py
@@ -1,3 +1,4 @@
+from friendships.api.paginations import FriendshipPagination
 from friendships.models import Friendship
 from rest_framework.test import APIClient
 from testing.testcases import TestCase
@@ -87,23 +88,23 @@ class FriendshipApiTests(TestCase):
         # get is ok
         response = self.anonymous_client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['followings']), 3)
+        self.assertEqual(len(response.data['results']), 3)
         # 确保按照时间倒序
-        ts0 = response.data['followings'][0]['created_at']
-        ts1 = response.data['followings'][1]['created_at']
-        ts2 = response.data['followings'][2]['created_at']
+        ts0 = response.data['results'][0]['created_at']
+        ts1 = response.data['results'][1]['created_at']
+        ts2 = response.data['results'][2]['created_at']
         self.assertEqual(ts0 > ts1, True)
         self.assertEqual(ts1 > ts2, True)
         self.assertEqual(
-            response.data['followings'][0]['user']['username'],
+            response.data['results'][0]['user']['username'],
             'dongxie_following2',
         )
         self.assertEqual(
-            response.data['followings'][1]['user']['username'],
+            response.data['results'][1]['user']['username'],
             'dongxie_following1',
         )
         self.assertEqual(
-            response.data['followings'][2]['user']['username'],
+            response.data['results'][2]['user']['username'],
             'dongxie_following0',
         )
 
@@ -115,16 +116,103 @@ class FriendshipApiTests(TestCase):
         # get is ok
         response = self.anonymous_client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['followers']), 2)
+        self.assertEqual(len(response.data['results']), 2)
         # 确保按照时间倒序
-        ts0 = response.data['followers'][0]['created_at']
-        ts1 = response.data['followers'][1]['created_at']
+        ts0 = response.data['results'][0]['created_at']
+        ts1 = response.data['results'][1]['created_at']
         self.assertEqual(ts0 > ts1, True)
         self.assertEqual(
-            response.data['followers'][0]['user']['username'],
+            response.data['results'][0]['user']['username'],
             'dongxie_follower1',
         )
         self.assertEqual(
-            response.data['followers'][1]['user']['username'],
+            response.data['results'][1]['user']['username'],
             'dongxie_follower0',
         )
+
+    def test_followers_pagination(self):
+        max_page_size = FriendshipPagination.max_page_size
+        page_size = FriendshipPagination.page_size
+        for i in range(page_size * 2):
+            follower = self.create_user('linghu_follower{}'.format(i))
+            Friendship.objects.create(from_user=follower, to_user=self.linghu)
+            if follower.id % 2 == 0:
+                Friendship.objects.create(from_user=self.dongxie, to_user=follower)
+
+        url = FOLLOWERS_URL.format(self.linghu.id)
+        self._test_friendship_pagination(url, page_size, max_page_size)
+
+        # anonymous hasn't followed any users
+        response = self.anonymous_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            self.assertEqual(result['has_followed'], False)
+
+        # dongxie has followed users with even id
+        response = self.dongxie_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            has_followed = (result['user']['id'] % 2 == 0)
+            self.assertEqual(result['has_followed'], has_followed)
+
+    def test_followings_pagination(self):
+        max_page_size = FriendshipPagination.max_page_size
+        page_size = FriendshipPagination.page_size
+        for i in range(page_size * 2):
+            following = self.create_user('linghu_following{}'.format(i))
+            Friendship.objects.create(from_user=self.linghu, to_user=following)
+            if following.id % 2 == 0:
+                Friendship.objects.create(from_user=self.dongxie, to_user=following)
+
+        url = FOLLOWINGS_URL.format(self.linghu.id)
+        self._test_friendship_pagination(url, page_size, max_page_size)
+
+        # anonymous hasn't followed any users
+        response = self.anonymous_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            self.assertEqual(result['has_followed'], False)
+
+        # dongxie has followed users with even id
+        response = self.dongxie_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            has_followed = (result['user']['id'] % 2 == 0)
+            self.assertEqual(result['has_followed'], has_followed)
+
+        # linghu has followed all his following users
+        response = self.linghu_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            self.assertEqual(result['has_followed'], True)
+
+    def _test_friendship_pagination(self, url, page_size, max_page_size):
+        response = self.anonymous_client.get(url, {'page': 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), page_size)
+        self.assertEqual(response.data['total_pages'], 2)
+        self.assertEqual(response.data['total_results'], page_size * 2)
+        self.assertEqual(response.data['page_number'], 1)
+        self.assertEqual(response.data['has_next_page'], True)
+
+        response = self.anonymous_client.get(url, {'page': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), page_size)
+        self.assertEqual(response.data['total_pages'], 2)
+        self.assertEqual(response.data['total_results'], page_size * 2)
+        self.assertEqual(response.data['page_number'], 2)
+        self.assertEqual(response.data['has_next_page'], False)
+
+        response = self.anonymous_client.get(url, {'page': 3})
+        self.assertEqual(response.status_code, 404)
+
+        # test user can not customize page_size exceeds max_page_size
+        response = self.anonymous_client.get(url, {'page': 1, 'size': max_page_size + 1})
+        self.assertEqual(len(response.data['results']), max_page_size)
+        self.assertEqual(response.data['total_pages'], 2)
+        self.assertEqual(response.data['total_results'], page_size * 2)
+        self.assertEqual(response.data['page_number'], 1)
+        self.assertEqual(response.data['has_next_page'], True)
+
+        # test user can customize page size by param size
+        response = self.anonymous_client.get(url, {'page': 1, 'size': 2})
+        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(response.data['total_pages'], page_size)
+        self.assertEqual(response.data['total_results'], page_size * 2)
+        self.assertEqual(response.data['page_number'], 1)
+        self.assertEqual(response.data['has_next_page'], True)

--- a/friendships/api/views.py
+++ b/friendships/api/views.py
@@ -1,14 +1,15 @@
+from django.contrib.auth.models import User
+from friendships.api.paginations import FriendshipPagination
+from friendships.api.serializers import (
+    FollowerSerializer,
+    FollowingSerializer,
+    FriendshipSerializerForCreate,
+)
+from friendships.models import Friendship
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
-from friendships.models import Friendship
-from friendships.api.serializers import (
-    FollowingSerializer,
-    FollowerSerializer,
-    FriendshipSerializerForCreate,
-)
-from django.contrib.auth.models import User
 
 
 class FriendshipViewSet(viewsets.GenericViewSet):
@@ -18,24 +19,25 @@ class FriendshipViewSet(viewsets.GenericViewSet):
     # 因为 detail=True 的 actions 会默认先去调用 get_object() 也就是
     # queryset.filter(pk=1) 查询一下这个 object 在不在
     queryset = User.objects.all()
+    # For POST request, which is how this class supposed to be called, below is not required
+    # But for testing w/ browser, w/o below, you'll get error as browser start with GET, so you can't do POST either
+    serializer_class = FriendshipSerializerForCreate
+    # 一般来说，不同的 views 所需要的 pagination 规则肯定是不同的，因此一般都需要自定义
+    pagination_class = FriendshipPagination
 
     @action(methods=['GET'], detail=True, permission_classes=[AllowAny])
     def followers(self, request, pk):
         friendships = Friendship.objects.filter(to_user_id=pk).order_by('-created_at')
-        serializer = FollowerSerializer(friendships, many=True)
-        return Response(
-            {'followers': serializer.data},
-            status=status.HTTP_200_OK,
-        )
+        page = self.paginate_queryset(friendships)
+        serializer = FollowerSerializer(page, many=True, context={'request': request})
+        return self.get_paginated_response(serializer.data)
 
     @action(methods=['GET'], detail=True, permission_classes=[AllowAny])
     def followings(self, request, pk):
         friendships = Friendship.objects.filter(from_user_id=pk).order_by('-created_at')
-        serializer = FollowingSerializer(friendships, many=True)
-        return Response(
-            {'followings': serializer.data},
-            status=status.HTTP_200_OK,
-        )
+        page = self.paginate_queryset(friendships)
+        serializer = FollowingSerializer(page, many=True, context={'request': request})
+        return self.get_paginated_response(serializer.data)
 
     @action(methods=['POST'], detail=True, permission_classes=[IsAuthenticated])
     def follow(self, request, pk):

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -31,3 +31,10 @@ class FriendshipService(object):
             to_user=user,
         ).prefetch_related('from_user')
         return [friendship.from_user for friendship in friendships]
+
+    @classmethod
+    def has_followed(cls, from_user, to_user):
+        return Friendship.objects.filter(
+            from_user=from_user,
+            to_user=to_user,
+        ).exists()


### PR DESCRIPTION
1. Apply code change and run your test as usual
2. Now if you have IDs with more than 20 follower or more than 20 followings, you'll see paginations
3. User id 67 have 43 followings(as returned by backend), and it's organized into 3 pages(total_pages), we are viewing page 2 in below, has_next_page was returned as true
<img width="480" alt="Screenshot 2022-11-28 at 4 35 03 PM" src="https://user-images.githubusercontent.com/3407579/204409537-4f570438-e307-4f33-9c01-51586ae6cdbc.png">
4. User ID 3 has 27 followers, two pages in total, current on 1st page, has next page true
<img width="491" alt="Screenshot 2022-11-28 at 5 55 51 PM" src="https://user-images.githubusercontent.com/3407579/204419409-9d1f1df3-9def-4782-8ce1-fe3caff5216e.png">
5. 我写了个建立多个账户，登录，互相follow，的脚本，晚点整理一下更新上来
6. !PROBLEM: 看一看这种pagination logic的问题
第二页最上面是43(见前面的图)，最后3个entry是6,5,4号user:
<img width="463" alt="Screenshot 2022-11-28 at 4 40 46 PM" src="https://user-images.githubusercontent.com/3407579/204410211-67eaf1d8-9ffc-45bf-b5da-cb0c98180284.png">
现在我再去让67号用户follow3个用户, 然后我们翻到第三页:
<img width="492" alt="Screenshot 2022-11-28 at 4 43 01 PM" src="https://user-images.githubusercontent.com/3407579/204410469-bb44a8f4-2a55-4b56-bef1-ec069af4517d.png">
现在可以看到, 6,5,4重复出现在了第三页的top, 总following用户数(total_result)从43-变成了46

