### PR TITLE
27-tweets-pagination

### DIFF
--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -151,7 +151,7 @@ class CommentApiTests(TestCase):
         self.create_comment(self.linghu, tweet)
         response = self.dongxie_client.get(TWEET_LIST_API, {'user_id': self.linghu.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['tweets'][0]['comments_count'], 1)
+        self.assertEqual(response.data['results'][0]['comments_count'], 1)
 
         # test newsfeeds list api
         self.create_comment(self.dongxie, tweet)

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -182,8 +182,8 @@ class LikeApiTests(TestCase):
         # test tweets list api
         response = self.dongxie_client.get(TWEET_LIST_API, {'user_id': self.linghu.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['tweets'][0]['has_liked'], True)
-        self.assertEqual(response.data['tweets'][0]['likes_count'], 1)
+        self.assertEqual(response.data['results'][0]['has_liked'], True)
+        self.assertEqual(response.data['results'][0]['likes_count'], 1)
 
         # test newsfeeds list api
         self.create_like(self.linghu, tweet)

--- a/tweets/api/tests.py
+++ b/tweets/api/tests.py
@@ -2,6 +2,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework.test import APIClient
 from testing.testcases import TestCase
 from tweets.models import Tweet, TweetPhoto
+from utils.paginations import EndlessPagination
 
 
 # 注意要加 '/' 结尾，要不然会产生 301 redirect
@@ -35,12 +36,12 @@ class TweetApiTests(TestCase):
         # 正常 request
         response = self.anonymous_client.get(TWEET_LIST_API, {'user_id': self.user1.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['tweets']), 3)
+        self.assertEqual(len(response.data['results']), 3)
         response = self.anonymous_client.get(TWEET_LIST_API, {'user_id': self.user2.id})
-        self.assertEqual(len(response.data['tweets']), 2)
+        self.assertEqual(len(response.data['results']), 2)
         # 检测排序是按照新创建的在前面的顺序来的
-        self.assertEqual(response.data['tweets'][0]['id'], self.tweets2[1].id)
-        self.assertEqual(response.data['tweets'][1]['id'], self.tweets2[0].id)
+        self.assertEqual(response.data['results'][0]['id'], self.tweets2[1].id)
+        self.assertEqual(response.data['results'][1]['id'], self.tweets2[0].id)
 
     def test_create_api(self):
         # 必须登录
@@ -154,3 +155,50 @@ class TweetApiTests(TestCase):
         profile = self.user1.profile
         self.assertEqual(response.data['user']['nickname'], profile.nickname)
         self.assertEqual(response.data['user']['avatar_url'], None)
+
+    def test_pagination(self):
+        page_size = EndlessPagination.page_size
+
+        # create page_size * 2 tweets
+        # we have created self.tweets1 in setUp
+        for i in range(page_size * 2 - len(self.tweets1)):
+            self.tweets1.append(self.create_tweet(self.user1, 'tweet{}'.format(i)))
+
+        tweets = self.tweets1[::-1]
+
+        # pull the first page
+        response = self.user1_client.get(TWEET_LIST_API, {'user_id': self.user1.id})
+        self.assertEqual(response.data['has_next_page'], True)
+        self.assertEqual(len(response.data['results']), page_size)
+        self.assertEqual(response.data['results'][0]['id'], tweets[0].id)
+        self.assertEqual(response.data['results'][1]['id'], tweets[1].id)
+        self.assertEqual(response.data['results'][page_size - 1]['id'], tweets[page_size - 1].id)
+
+        # pull the second page
+        response = self.user1_client.get(TWEET_LIST_API, {
+            'created_at__lt': tweets[page_size - 1].created_at,
+            'user_id': self.user1.id,
+        })
+        self.assertEqual(response.data['has_next_page'], False)
+        self.assertEqual(len(response.data['results']), page_size)
+        self.assertEqual(response.data['results'][0]['id'], tweets[page_size].id)
+        self.assertEqual(response.data['results'][1]['id'], tweets[page_size + 1].id)
+        self.assertEqual(response.data['results'][page_size - 1]['id'], tweets[2 * page_size - 1].id)
+
+        # pull latest newsfeeds
+        response = self.user1_client.get(TWEET_LIST_API, {
+            'created_at__gt': tweets[0].created_at,
+            'user_id': self.user1.id,
+        })
+        self.assertEqual(response.data['has_next_page'], False)
+        self.assertEqual(len(response.data['results']), 0)
+
+        new_tweet = self.create_tweet(self.user1, 'a new tweet comes in')
+
+        response = self.user1_client.get(TWEET_LIST_API, {
+            'created_at__gt': tweets[0].created_at,
+            'user_id': self.user1.id,
+        })
+        self.assertEqual(response.data['has_next_page'], False)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['id'], new_tweet.id)

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -9,6 +9,7 @@ from tweets.api.serializers import (
 )
 from tweets.models import Tweet
 from utils.decorators import required_params
+from utils.paginations import EndlessPagination
 
 
 class TweetViewSet(viewsets.GenericViewSet,
@@ -19,6 +20,7 @@ class TweetViewSet(viewsets.GenericViewSet,
     """
     queryset = Tweet.objects.all()
     serializer_class = TweetSerializerForCreate
+    pagination_class = EndlessPagination
 
     def get_permissions(self):
         if self.action in ['list', 'retrieve']:
@@ -45,14 +47,13 @@ class TweetViewSet(viewsets.GenericViewSet,
         tweets = Tweet.objects.filter(
             user_id=request.query_params['user_id']
         ).order_by('-created_at')
+        tweets = self.paginate_queryset(tweets)
         serializer = TweetSerializer(
             tweets,
             context={'request': request},
             many=True,
         )
-        # 一般来说 json 格式的 response 默认都要用 hash 的格式
-        # 而不能用 list 的格式（约定俗成）
-        return Response({'tweets': serializer.data})
+        return self.get_paginated_response(serializer.data)
 
     def create(self, request, *args, **kwargs):
         """

--- a/utils/paginations.py
+++ b/utils/paginations.py
@@ -1,0 +1,43 @@
+from rest_framework.pagination import BasePagination
+from rest_framework.response import Response
+
+
+class EndlessPagination(BasePagination):
+    page_size = 20
+
+    def __init__(self):
+        super(EndlessPagination, self).__init__()
+        self.has_next_page = False
+
+    def to_html(self):
+        pass
+
+    def paginate_queryset(self, queryset, request, view=None):
+        if 'created_at__gt' in request.query_params:
+            # created_at__gt 用于下拉刷新的时候加载最新的内容进来
+            # 为了简便起见，下拉刷新不做翻页机制，直接加载所有更新的数据
+            # 因为如果数据很久没有更新的话，不会采用下拉刷新的方式进行更新，而是重新加载最新的数据
+            created_at__gt = request.query_params['created_at__gt']
+            queryset = queryset.filter(created_at__gt=created_at__gt)
+            self.has_next_page = False
+            return queryset.order_by('-created_at')
+
+        if 'created_at__lt' in request.query_params:
+            # created_at__lt 用于向上滚屏（往下翻页）的时候加载下一页的数据
+            # 寻找 created_at < created_at__lt 的 objects 里按照 created_at 倒序的前
+            # page_size + 1 个 objects
+            # 比如目前的 created_at 列表是 [10, 9, 8, 7 .. 1] 如果 created_at__lt=10
+            # page_size = 2 则应该返回 [9, 8, 7]，多返回一个 object 的原因是为了判断是否
+            # 还有下一页从而减少一次空加载。
+            created_at__lt = request.query_params['created_at__lt']
+            queryset = queryset.filter(created_at__lt=created_at__lt)
+
+        queryset = queryset.order_by('-created_at')[:self.page_size + 1]
+        self.has_next_page = len(queryset) > self.page_size
+        return queryset[:self.page_size]
+
+    def get_paginated_response(self, data):
+        return Response({
+            'has_next_page': self.has_next_page,
+            'results': data,
+        })


### PR DESCRIPTION
1. No migrations for this commit
2. Make sure you pass all **40 tests**
3. EndlessPagination(Cursor)
4. user68目前一共不到20个tweets(tweets id[48, 57], in total: 10)，一次都取回来了，所以has_next_page: false
<img width="462" alt="Screenshot 2022-11-28 at 5 13 51 PM" src="https://user-images.githubusercontent.com/3407579/204419662-f46ddb2e-310f-4dba-9917-f3076b4ffac6.png">
<img width="618" alt="Screenshot 2022-11-28 at 5 16 17 PM" src="https://user-images.githubusercontent.com/3407579/204419745-1451b52f-2815-4c1b-a86f-db5715df5b38.png">
5. 再加10个推(tweets id: [48, 67])一共20个也是1个page
<img width="620" alt="Screenshot 2022-11-28 at 5 16 36 PM" src="https://user-images.githubusercontent.com/3407579/204419819-26c9b436-9358-4f0a-87a9-dfa6a568b4e4.png">
6. [48, 90] 现在一共43个tweets了, has_next_pagei变成true了
<img width="559" alt="Screenshot 2022-11-28 at 5 59 50 PM" src="https://user-images.githubusercontent.com/3407579/204419901-a3bffd61-0024-46ce-b04f-886b85be316a.png">
注意第一页最后一个tweet(71号)的时间戳: 2022-11-29T01:17:31.620976Z
<img width="559" alt="Screenshot 2022-11-28 at 6 01 39 PM" src="https://user-images.githubusercontent.com/3407579/204420150-bd490d2b-b7a1-401b-a396-f9134a56fbee.png">

7. 怎么取下一页: http://192.168.64.34:8000/api/tweets/?user_id=68&created_at__lt=2022-11-29T01:17:31.620976Z 我们用上一页最后一个tweet的时间戳，而且让create time 严格小于上一个时间戳，这样分页就不会出现 https://github.com/byegates/twitter2/pull/55 里面翻页同时有新tweets造成的顺序混乱的问题
<img width="619" alt="Screenshot 2022-11-28 at 5 42 06 PM" src="https://user-images.githubusercontent.com/3407579/204420030-533a8e08-577e-40a0-92ed-18592b211f2e.png">
8. [51, 70] 一也还是20个
<img width="622" alt="Screenshot 2022-11-28 at 5 42 18 PM" src="https://user-images.githubusercontent.com/3407579/204420568-53bca10b-1f2a-40d1-b52b-ceab827e67a6.png">
