### PR TITLE
28-newsfeeds-pagination

### DIFF
--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -158,4 +158,4 @@ class CommentApiTests(TestCase):
         self.create_newsfeed(self.dongxie, tweet)
         response = self.dongxie_client.get(NEWSFEED_LIST_API)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['comments_count'], 2)
+        self.assertEqual(response.data['results'][0]['tweet']['comments_count'], 2)

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -190,8 +190,8 @@ class LikeApiTests(TestCase):
         self.create_newsfeed(self.dongxie, tweet)
         response = self.dongxie_client.get(NEWSFEED_LIST_API)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['has_liked'], True)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['likes_count'], 2)
+        self.assertEqual(response.data['results'][0]['tweet']['has_liked'], True)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 2)
 
         # test likes details
         url = TWEET_DETAIL_API.format(tweet.id)

--- a/newsfeeds/api/tests.py
+++ b/newsfeeds/api/tests.py
@@ -1,7 +1,8 @@
-from newsfeeds.models import NewsFeed
 from friendships.models import Friendship
+from newsfeeds.models import NewsFeed
 from rest_framework.test import APIClient
 from testing.testcases import TestCase
+from utils.paginations import EndlessPagination
 
 
 NEWSFEEDS_URL = '/api/newsfeeds/'
@@ -38,11 +39,11 @@ class NewsFeedApiTests(TestCase):
         # 一开始啥都没有
         response = self.linghu_client.get(NEWSFEEDS_URL)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['newsfeeds']), 0)
+        self.assertEqual(len(response.data['results']), 0)
         # 自己发的信息是可以看到的
         self.linghu_client.post(POST_TWEETS_URL, {'content': 'Hello World'})
         response = self.linghu_client.get(NEWSFEEDS_URL)
-        self.assertEqual(len(response.data['newsfeeds']), 1)
+        self.assertEqual(len(response.data['results']), 1)
         # 关注之后可以看到别人发的
         self.linghu_client.post(FOLLOW_URL.format(self.dongxie.id))
         response = self.dongxie_client.post(POST_TWEETS_URL, {
@@ -50,5 +51,61 @@ class NewsFeedApiTests(TestCase):
         })
         posted_tweet_id = response.data['id']
         response = self.linghu_client.get(NEWSFEEDS_URL)
-        self.assertEqual(len(response.data['newsfeeds']), 2)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['id'], posted_tweet_id)
+        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(response.data['results'][0]['tweet']['id'], posted_tweet_id)
+
+    def test_pagination(self):
+        page_size = EndlessPagination.page_size
+        followed_user = self.create_user('followed')
+        newsfeeds = []
+        for i in range(page_size * 2):
+            tweet = self.create_tweet(followed_user)
+            newsfeed = self.create_newsfeed(user=self.linghu, tweet=tweet)
+            newsfeeds.append(newsfeed)
+
+        newsfeeds = newsfeeds[::-1]
+
+        # pull the first page
+        response = self.linghu_client.get(NEWSFEEDS_URL)
+        self.assertEqual(response.data['has_next_page'], True)
+        self.assertEqual(len(response.data['results']), page_size)
+        self.assertEqual(response.data['results'][0]['id'], newsfeeds[0].id)
+        self.assertEqual(response.data['results'][1]['id'], newsfeeds[1].id)
+        self.assertEqual(
+            response.data['results'][page_size - 1]['id'],
+            newsfeeds[page_size - 1].id,
+        )
+
+        # pull the second page
+        response = self.linghu_client.get(
+            NEWSFEEDS_URL,
+            {'created_at__lt': newsfeeds[page_size - 1].created_at},
+        )
+        self.assertEqual(response.data['has_next_page'], False)
+        results = response.data['results']
+        self.assertEqual(len(results), page_size)
+        self.assertEqual(results[0]['id'], newsfeeds[page_size].id)
+        self.assertEqual(results[1]['id'], newsfeeds[page_size + 1].id)
+        self.assertEqual(
+            results[page_size - 1]['id'],
+            newsfeeds[2 * page_size - 1].id,
+        )
+
+        # pull latest newsfeeds
+        response = self.linghu_client.get(
+            NEWSFEEDS_URL,
+            {'created_at__gt': newsfeeds[0].created_at},
+        )
+        self.assertEqual(response.data['has_next_page'], False)
+        self.assertEqual(len(response.data['results']), 0)
+
+        tweet = self.create_tweet(followed_user)
+        new_newsfeed = self.create_newsfeed(user=self.linghu, tweet=tweet)
+
+        response = self.linghu_client.get(
+            NEWSFEEDS_URL,
+            {'created_at__gt': newsfeeds[0].created_at},
+        )
+        self.assertEqual(response.data['has_next_page'], False)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['id'], new_newsfeed.id)

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -1,13 +1,13 @@
-from rest_framework import viewsets, status
-from rest_framework.decorators import permission_classes
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
-from newsfeeds.models import NewsFeed
 from newsfeeds.api.serializers import NewsFeedSerializer
+from newsfeeds.models import NewsFeed
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+from utils.paginations import EndlessPagination
 
 
 class NewsFeedViewSet(viewsets.GenericViewSet):
     permission_classes = [IsAuthenticated]
+    pagination_class = EndlessPagination
 
     def get_queryset(self):
         # 自定义 queryset，因为 newsfeed 的查看是有权限的
@@ -17,11 +17,10 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         return NewsFeed.objects.filter(user=self.request.user)
 
     def list(self, request):
+        queryset = self.paginate_queryset(self.get_queryset())
         serializer = NewsFeedSerializer(
-            self.get_queryset(),
+            queryset,
             context={'request': request},
             many=True,
         )
-        return Response({
-            'newsfeeds': serializer.data,
-        }, status=status.HTTP_200_OK)
+        return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
1. No new migrations in this commit
2. **41 tests** should pass
3. Before change newsfeeds is showing all 43 tweets in one page. (newsfeed id: [204, 246])
<img width="639" alt="Screenshot 2022-11-28 at 6 16 26 PM" src="https://user-images.githubusercontent.com/3407579/204422324-f548fdcf-0a4c-4d64-94f6-81adb8f4d371.png">
<img width="638" alt="Screenshot 2022-11-28 at 6 17 17 PM" src="https://user-images.githubusercontent.com/3407579/204422418-cf029eb2-24ad-4018-871e-e0e975c2b7a8.png">
4. After change, has next page true, only 20 msgs per page: fewsfeed id: [227, 246]
<img width="634" alt="Screenshot 2022-11-28 at 6 18 22 PM" src="https://user-images.githubusercontent.com/3407579/204422555-1fbc9aab-a6e3-4f34-b30b-90a02d61eedd.png">
<img width="646" alt="Screenshot 2022-11-28 at 6 19 05 PM" src="https://user-images.githubusercontent.com/3407579/204422657-dde31391-bdfb-4d1f-be29-f140d119c155.png">
5. http://192.168.64.34:8000/api/newsfeeds/?created_at__lt=2022-11-29T01:17:31.620976Z, see next page:
<img width="631" alt="Screenshot 2022-11-28 at 6 21 06 PM" src="https://user-images.githubusercontent.com/3407579/204422924-2d85ed6a-e1f9-4cff-bbdf-abfec5f326c4.png">
<img width="641" alt="Screenshot 2022-11-28 at 6 21 17 PM" src="https://user-images.githubusercontent.com/3407579/204422957-234feb03-4f67-4f5b-805b-49c000e6c88b.png">