### PR TITLE
29-add-memcached

### DIFF
--- a/friendships/api/serializers.py
+++ b/friendships/api/serializers.py
@@ -5,6 +5,21 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 
+class FollowingUserIdSetMixin:
+
+    @property
+    def following_user_id_set(self: serializers.ModelSerializer):
+        if self.context['request'].user.is_anonymous:
+            return {}
+        if hasattr(self, '_cached_following_user_id_set'):
+            return self._cached_following_user_id_set
+        user_id_set = FriendshipService.get_following_user_id_set(
+            self.context['request'].user.id,
+        )
+        setattr(self, '_cached_following_user_id_set', user_id_set)
+        return user_id_set
+
+
 class FriendshipSerializerForCreate(serializers.ModelSerializer):
     from_user_id = serializers.IntegerField()
     to_user_id = serializers.IntegerField()
@@ -32,7 +47,7 @@ class FriendshipSerializerForCreate(serializers.ModelSerializer):
 # 可以通过 source=xxx 指定去访问每个 model instance 的 xxx 方法
 # 即 model_instance.xxx 来获得数据
 # https://www.django-rest-framework.org/api-guide/serializers/#specifying-fields-explicitly
-class FollowerSerializer(serializers.ModelSerializer):
+class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
     user = UserSerializerForFriendship(source='from_user')
     created_at = serializers.DateTimeField()
     has_followed = serializers.SerializerMethodField()
@@ -42,14 +57,10 @@ class FollowerSerializer(serializers.ModelSerializer):
         fields = ('user', 'created_at', 'has_followed')
 
     def get_has_followed(self, obj):
-        if self.context['request'].user.is_anonymous:
-            return False
-        # <TODO> 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
-        # 我们将在后序的课程中解决这个问题
-        return FriendshipService.has_followed(self.context['request'].user, obj.from_user)
+        return obj.from_user_id in self.following_user_id_set
 
 
-class FollowingSerializer(serializers.ModelSerializer):
+class FollowingSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
     user = UserSerializerForFriendship(source='to_user')
     created_at = serializers.DateTimeField()
     has_followed = serializers.SerializerMethodField()
@@ -59,9 +70,4 @@ class FollowingSerializer(serializers.ModelSerializer):
         fields = ('user', 'created_at', 'has_followed')
 
     def get_has_followed(self, obj):
-        if self.context['request'].user.is_anonymous:
-            return False
-
-        # <TODO> 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
-        # 我们将在后序的课程中解决这个问题
-        return FriendshipService.has_followed(self.context['request'].user, obj.to_user)
+       return obj.to_user_id in self.following_user_id_set

--- a/friendships/api/tests.py
+++ b/friendships/api/tests.py
@@ -13,6 +13,7 @@ FOLLOWINGS_URL = '/api/friendships/{}/followings/'
 class FriendshipApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.linghu = self.create_user('linghu')
         self.linghu_client = APIClient()
         self.linghu_client.force_authenticate(self.linghu)

--- a/friendships/api/views.py
+++ b/friendships/api/views.py
@@ -6,6 +6,7 @@ from friendships.api.serializers import (
     FriendshipSerializerForCreate,
 )
 from friendships.models import Friendship
+from friendships.services import FriendshipService
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated, AllowAny
@@ -58,6 +59,7 @@ class FriendshipViewSet(viewsets.GenericViewSet):
                 'errors': serializer.errors,
             }, status=status.HTTP_400_BAD_REQUEST)
         serializer.save()
+        FriendshipService.invalidate_following_cache(request.user.id)
         return Response({'success': True}, status=status.HTTP_201_CREATED)
 
     @action(methods=['POST'], detail=True, permission_classes=[IsAuthenticated])
@@ -79,4 +81,5 @@ class FriendshipViewSet(viewsets.GenericViewSet):
             from_user=request.user,
             to_user=pk,
         ).delete()
+        FriendshipService.invalidate_following_cache(request.user.id)
         return Response({'success': True, 'deleted': deleted})

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -1,4 +1,9 @@
+from django.conf import settings
+from django.core.cache import caches
 from friendships.models import Friendship
+from twitter.cache import FOLLOWINGS_PATTERN
+
+cache = caches['testing'] if settings.TESTING else caches['default']
 
 
 class FriendshipService(object):
@@ -33,8 +38,21 @@ class FriendshipService(object):
         return [friendship.from_user for friendship in friendships]
 
     @classmethod
-    def has_followed(cls, from_user, to_user):
-        return Friendship.objects.filter(
-            from_user=from_user,
-            to_user=to_user,
-        ).exists()
+    def get_following_user_id_set(cls, from_user_id):
+        key = FOLLOWINGS_PATTERN.format(user_id=from_user_id)
+        user_id_set = cache.get(key)
+        if user_id_set is not None:
+            return user_id_set
+
+        friendships = Friendship.objects.filter(from_user_id=from_user_id)
+        user_id_set = set([
+            fs.to_user_id
+            for fs in friendships
+        ])
+        cache.set(key, user_id_set)
+        return user_id_set
+
+    @classmethod
+    def invalidate_following_cache(cls, from_user_id):
+        key = FOLLOWINGS_PATTERN.format(user_id=from_user_id)
+        cache.delete(key)

--- a/friendships/tests.py
+++ b/friendships/tests.py
@@ -1,0 +1,26 @@
+from friendships.models import Friendship
+from friendships.services import FriendshipService
+from testing.testcases import TestCase
+
+
+class FriendshipServiceTests(TestCase):
+
+    def setUp(self):
+        self.clear_cache()
+        self.linghu = self.create_user('linghu')
+        self.dongxie = self.create_user('dongxie')
+
+    def test_get_followings(self):
+        user1 = self.create_user('user1')
+        user2 = self.create_user('user2')
+        for to_user in [user1, user2, self.dongxie]:
+            Friendship.objects.create(from_user=self.linghu, to_user=to_user)
+        FriendshipService.invalidate_following_cache(self.linghu.id)
+
+        user_id_set = FriendshipService.get_following_user_id_set(self.linghu.id)
+        self.assertSetEqual(user_id_set, {user1.id, user2.id, self.dongxie.id})
+
+        Friendship.objects.filter(from_user=self.linghu, to_user=self.dongxie).delete()
+        FriendshipService.invalidate_following_cache(self.linghu.id)
+        user_id_set = FriendshipService.get_following_user_id_set(self.linghu.id)
+        self.assertSetEqual(user_id_set, {user1.id, user2.id})

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-filter==22.1
 django-notifications-hq==1.7.0
 django-storages==1.13.1
 boto3==1.26.17
+pymemcache==4.0.0

--- a/script2.sh
+++ b/script2.sh
@@ -30,6 +30,8 @@ sudo apt-get upgrade
 sudo apt-get install python3.10-venv
 # useful utility
 sudo apt-get install tree
+# memcached, for later use
+sudo apt-get install memcached libmemcached-tools
 
 # mysql related
 sudo apt-get install mysql-server

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -1,6 +1,7 @@
 from comments.models import Comment
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import caches
 from django.test import TestCase as DjangoTestCase
 from likes.models import Like
 from newsfeeds.models import NewsFeed
@@ -9,6 +10,9 @@ from tweets.models import Tweet
 
 
 class TestCase(DjangoTestCase):
+
+    def clear_cache(self):
+        caches['testing'].clear()
 
     @property
     def anonymous_client(self):

--- a/twitter/cache.py
+++ b/twitter/cache.py
@@ -1,0 +1,1 @@
+FOLLOWINGS_PATTERN = 'followings:{user_id}'

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -171,6 +171,24 @@ AWS_S3_REGION_NAME = 'us-west-1'
 # - media 里使用户上传的数据文件，而不是代码
 MEDIA_ROOT = 'media/'
 
+# https://docs.djangoproject.com/en/4.1/topics/cache/
+# use `pip install pymemcache==4.0.0`
+# DO NOT pip install memcache or django-memcached or python-memcached
+# python-memcached is no longer manintained (not supported by Django either?)
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': 86400,
+    },
+    'testing': {
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': 86400,
+        'KEY_PREFIX': 'testing',
+    },
+}
+
 try:
     from .local_settings import *
 except:


### PR DESCRIPTION
1. No new migrations
2. run 'pip install -r requirements.txt' to make sure you get pymemcache==4.0.0 installed
3. run 'sudo apt-get install memcached libmemcached-tools' to make sure memcached and libmemcached-tools is installed on ubuntu server
4. Make sure 42 unit test cases pass
5. We won't really see much differences as we are not using tons of data, but we can check memcached stats to at least know it's running
6. at ubuntu server terminal, run 'ps -ef | grep -i memc', you should see something like below:
<img width="1118" alt="Screenshot 2022-11-29 at 12 04 25 AM" src="https://user-images.githubusercontent.com/3407579/204472945-2cf27341-40db-4732-a2c7-449ddd572a8e.png">
-m 64 means memcached is running with 64mb memory allocated, and on port 11211 with ip address 0.0.0.0
7. at ubuntu server terminal run 'memcstat --servers localhost', you'll see things like
<img width="691" alt="Screenshot 2022-11-29 at 1 00 05 AM" src="https://user-images.githubusercontent.com/3407579/204484814-cc6ab3e6-438e-4de4-8129-a5fd143da08f.png">
8. Go to your browser, check a few people's followings
9. then run 'memcstat --servers localhost' again at memcached terminal, now you see the stats change:
<img width="128" alt="Screenshot 2022-11-29 at 1 01 05 AM" src="https://user-images.githubusercontent.com/3407579/204484962-abba7b6f-880f-48fe-b5f0-6b222ae175ac.png">
11. run 'memcdump --servers localhost'
<img width="692" alt="Screenshot 2022-11-29 at 1 03 03 AM" src="https://user-images.githubusercontent.com/3407579/204485375-af9fdbf2-6a91-4406-9fe8-bf70181fc724.png">