### PR TITLE
30-support-user-cache

### DIFF
--- a/accounts/api/tests.py
+++ b/accounts/api/tests.py
@@ -14,6 +14,7 @@ USER_PROFILE_DETAIL_URL = '/api/profiles/{}/'
 class AccountApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         # 这个函数会在每个 test function 执行的时候被执行
         self.client = APIClient()
         self.user = self.create_user(

--- a/accounts/listeners.py
+++ b/accounts/listeners.py
@@ -1,0 +1,10 @@
+def user_changed(sender, instance, **kwargs):
+    # import 写在函数里面避免循环依赖
+    from accounts.services import UserService
+    UserService.invalidate_user(instance.id)
+
+
+def profile_changed(sender, instance, **kwargs):
+    # import 写在函数里面避免循环依赖
+    from accounts.services import UserService
+    UserService.invalidate_profile(instance.user_id)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,5 +1,7 @@
-from django.db import models
+from accounts.listeners import user_changed, profile_changed
 from django.contrib.auth.models import User
+from django.db import models
+from django.db.models.signals import post_save, pre_delete
 
 
 class UserProfile(models.Model):
@@ -24,9 +26,12 @@ class UserProfile(models.Model):
 # 这种写法实际上是一个利用 Python 的灵活性进行 hack 的方法，这样会方便我们通过 user 快速
 # 访问到对应的 profile 信息。
 def get_profile(user):
+    # import 放在函数里面避免循环依赖
+    from accounts.services import UserService
+
     if hasattr(user, '_cached_user_profile'):
         return getattr(user, '_cached_user_profile')
-    profile, _ = UserProfile.objects.get_or_create(user=user)
+    profile = UserService.get_profile_through_cache(user.id)
     # 使用 user 对象的属性进行缓存(cache)，避免多次调用同一个 user 的 profile 时
     # 重复的对数据库进行查询
     setattr(user, '_cached_user_profile', profile)
@@ -35,3 +40,10 @@ def get_profile(user):
 
 # 给 User Model 增加了一个 profile 的 property 方法用于快捷访问
 User.profile = property(get_profile)
+
+# hook up with listeners to invalidate cache
+pre_delete.connect(user_changed, sender=User)
+post_save.connect(user_changed, sender=User)
+
+pre_delete.connect(profile_changed, sender=UserProfile)
+post_save.connect(profile_changed, sender=UserProfile)

--- a/accounts/services.py
+++ b/accounts/services.py
@@ -1,0 +1,53 @@
+from accounts.models import UserProfile
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.cache import caches
+from twitter.cache import USER_PATTERN, USER_PROFILE_PATTERN
+
+cache = caches['testing'] if settings.TESTING else caches['default']
+
+
+class UserService:
+
+    @classmethod
+    def get_user_through_cache(cls, user_id):
+        key = USER_PATTERN.format(user_id=user_id)
+
+        # read from cache first
+        user = cache.get(key)
+        # cache hit return
+        if user is not None:
+            return user
+
+        # cache miss, read from db
+        try:
+            user = User.objects.get(id=user_id)
+            cache.set(key, user)
+        except User.DoesNotExist:
+            user = None
+        return user
+
+    @classmethod
+    def invalidate_user(cls, user_id):
+        key = USER_PATTERN.format(user_id=user_id)
+        cache.delete(key)
+
+    @classmethod
+    def get_profile_through_cache(cls, user_id):
+        key = USER_PROFILE_PATTERN.format(user_id=user_id)
+
+        # read from cache first
+        profile = cache.get(key)
+        # cache hit return
+        if profile is not None:
+            return profile
+
+        # cache miss, read from db
+        profile, _ = UserProfile.objects.get_or_create(user_id=user_id)
+        cache.set(key, profile)
+        return profile
+
+    @classmethod
+    def invalidate_profile(cls, user_id):
+        key = USER_PROFILE_PATTERN.format(user_id=user_id)
+        cache.delete(key)

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -4,6 +4,9 @@ from testing.testcases import TestCase
 
 class UserProfileTests(TestCase):
 
+    def setUp(self):
+        self.clear_cache()
+
     def test_profile_property(self):
         linghu = self.create_user('linghu')
         self.assertEqual(UserProfile.objects.count(), 0)

--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -13,6 +13,7 @@ NEWSFEED_LIST_API = '/api/newsfeeds/'
 class CommentApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.linghu = self.create_user('linghu')
         self.linghu_client = APIClient()
         self.linghu_client.force_authenticate(self.linghu)

--- a/comments/models.py
+++ b/comments/models.py
@@ -1,3 +1,4 @@
+from accounts.services import UserService
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -34,3 +35,7 @@ class Comment(models.Model):
             content_type=ContentType.objects.get_for_model(Comment),
             object_id=self.id,
         ).order_by('-created_at')
+
+    @property
+    def cached_user(self):
+        return UserService.get_user_through_cache(self.user_id)

--- a/comments/tests.py
+++ b/comments/tests.py
@@ -4,6 +4,7 @@ from testing.testcases import TestCase
 class CommentModelTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.linghu = self.create_user('linghu')
         self.tweet = self.create_tweet(self.linghu)
         self.comment = self.create_comment(self.linghu, self.tweet)

--- a/friendships/api/serializers.py
+++ b/friendships/api/serializers.py
@@ -48,7 +48,7 @@ class FriendshipSerializerForCreate(serializers.ModelSerializer):
 # 即 model_instance.xxx 来获得数据
 # https://www.django-rest-framework.org/api-guide/serializers/#specifying-fields-explicitly
 class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
-    user = UserSerializerForFriendship(source='from_user')
+    user = UserSerializerForFriendship(source='cached_from_user')
     created_at = serializers.DateTimeField()
     has_followed = serializers.SerializerMethodField()
 
@@ -61,7 +61,7 @@ class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
 
 
 class FollowingSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
-    user = UserSerializerForFriendship(source='to_user')
+    user = UserSerializerForFriendship(source='cached_to_user')
     created_at = serializers.DateTimeField()
     has_followed = serializers.SerializerMethodField()
 

--- a/friendships/api/views.py
+++ b/friendships/api/views.py
@@ -59,7 +59,6 @@ class FriendshipViewSet(viewsets.GenericViewSet):
                 'errors': serializer.errors,
             }, status=status.HTTP_400_BAD_REQUEST)
         serializer.save()
-        FriendshipService.invalidate_following_cache(request.user.id)
         return Response({'success': True}, status=status.HTTP_201_CREATED)
 
     @action(methods=['POST'], detail=True, permission_classes=[IsAuthenticated])
@@ -81,5 +80,4 @@ class FriendshipViewSet(viewsets.GenericViewSet):
             from_user=request.user,
             to_user=pk,
         ).delete()
-        FriendshipService.invalidate_following_cache(request.user.id)
         return Response({'success': True, 'deleted': deleted})

--- a/friendships/listeners.py
+++ b/friendships/listeners.py
@@ -1,0 +1,4 @@
+def friendship_changed(sender, instance, **kwargs):
+    # import 写在函数里面避免循环依赖
+    from friendships.services import FriendshipService
+    FriendshipService.invalidate_following_cache(instance.from_user_id)

--- a/friendships/models.py
+++ b/friendships/models.py
@@ -1,5 +1,8 @@
-from django.db import models
+from accounts.services import UserService
 from django.contrib.auth.models import User
+from django.db import models
+from django.db.models.signals import post_save, pre_delete
+from friendships.listeners import friendship_changed
 
 
 class Friendship(models.Model):
@@ -28,3 +31,16 @@ class Friendship(models.Model):
 
     def __str__(self):
         return '{} followed {}'.format(self.from_user_id, self.to_user_id)
+
+    @property
+    def cached_from_user(self):
+        return UserService.get_user_through_cache(self.from_user_id)
+
+    @property
+    def cached_to_user(self):
+        return UserService.get_user_through_cache(self.to_user_id)
+
+
+# hook up with listeners to invalidate cache
+pre_delete.connect(friendship_changed, sender=Friendship)
+post_save.connect(friendship_changed, sender=Friendship)

--- a/friendships/tests.py
+++ b/friendships/tests.py
@@ -15,12 +15,10 @@ class FriendshipServiceTests(TestCase):
         user2 = self.create_user('user2')
         for to_user in [user1, user2, self.dongxie]:
             Friendship.objects.create(from_user=self.linghu, to_user=to_user)
-        FriendshipService.invalidate_following_cache(self.linghu.id)
 
         user_id_set = FriendshipService.get_following_user_id_set(self.linghu.id)
         self.assertSetEqual(user_id_set, {user1.id, user2.id, self.dongxie.id})
 
         Friendship.objects.filter(from_user=self.linghu, to_user=self.dongxie).delete()
-        FriendshipService.invalidate_following_cache(self.linghu.id)
         user_id_set = FriendshipService.get_following_user_id_set(self.linghu.id)
         self.assertSetEqual(user_id_set, {user1.id, user2.id})

--- a/inbox/api/tests.py
+++ b/inbox/api/tests.py
@@ -9,6 +9,7 @@ NOTIFICATION_URL = '/api/notifications/'
 class NotificationTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.linghu, self.linghu_client = self.create_user_and_client('linghu')
         self.dongxie, self.dongxie_client = self.create_user_and_client('dong')
         self.dongxie_tweet = self.create_tweet(self.dongxie)

--- a/inbox/tests.py
+++ b/inbox/tests.py
@@ -6,6 +6,7 @@ from notifications.models import Notification
 class NotificationServiceTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.linghu = self.create_user('linghu')
         self.dongxie = self.create_user('dongxie')
         self.linghu_tweet = self.create_tweet(self.linghu)

--- a/likes/api/serializers.py
+++ b/likes/api/serializers.py
@@ -8,7 +8,7 @@ from tweets.models import Tweet
 
 
 class LikeSerializer(serializers.ModelSerializer):
-    user = UserSerializerForLike()
+    user = UserSerializerForLike(source='cached_user')
 
     class Meta:
         model = Like

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -13,6 +13,7 @@ NEWSFEED_LIST_API = '/api/newsfeeds/'
 class LikeApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.linghu, self.linghu_client = self.create_user_and_client('linghu')
         self.dongxie, self.dongxie_client = self.create_user_and_client('dongxie')
 

--- a/likes/models.py
+++ b/likes/models.py
@@ -1,3 +1,4 @@
+from accounts.services import UserService
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -33,3 +34,7 @@ class Like(models.Model):
             self.content_type,
             self.object_id,
         )
+
+    @property
+    def cached_user(self):
+        return UserService.get_user_through_cache(self.user_id)

--- a/newsfeeds/api/serializers.py
+++ b/newsfeeds/api/serializers.py
@@ -8,4 +8,4 @@ class NewsFeedSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = NewsFeed
-        fields = ('id', 'created_at', 'user', 'tweet')
+        fields = ('id', 'created_at', 'tweet')

--- a/newsfeeds/api/tests.py
+++ b/newsfeeds/api/tests.py
@@ -13,6 +13,7 @@ FOLLOW_URL = '/api/friendships/{}/follow/'
 class NewsFeedApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.linghu = self.create_user('linghu')
         self.linghu_client = APIClient()
         self.linghu_client.force_authenticate(self.linghu)
@@ -109,3 +110,29 @@ class NewsFeedApiTests(TestCase):
         self.assertEqual(response.data['has_next_page'], False)
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['id'], new_newsfeed.id)
+
+    def test_user_cache(self):
+        profile = self.dongxie.profile
+        profile.nickname = 'huanglaoxie'
+        profile.save()
+
+        self.assertEqual(self.linghu.username, 'linghu')
+        self.create_newsfeed(self.dongxie, self.create_tweet(self.linghu))
+        self.create_newsfeed(self.dongxie, self.create_tweet(self.dongxie))
+
+        response = self.dongxie_client.get(NEWSFEEDS_URL)
+        results = response.data['results']
+        self.assertEqual(results[0]['tweet']['user']['username'], 'dongxie')
+        self.assertEqual(results[0]['tweet']['user']['nickname'], 'huanglaoxie')
+        self.assertEqual(results[1]['tweet']['user']['username'], 'linghu')
+
+        self.linghu.username = 'linghuchong'
+        self.linghu.save()
+        profile.nickname = 'huangyaoshi'
+        profile.save()
+
+        response = self.dongxie_client.get(NEWSFEEDS_URL)
+        results = response.data['results']
+        self.assertEqual(results[0]['tweet']['user']['username'], 'dongxie')
+        self.assertEqual(results[0]['tweet']['user']['nickname'], 'huangyaoshi')
+        self.assertEqual(results[1]['tweet']['user']['username'], 'linghuchong')

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -10,7 +10,7 @@ from tweets.services import TweetService
 
 
 class TweetSerializer(serializers.ModelSerializer):
-    user = UserSerializerForTweet()
+    user = UserSerializerForTweet(source='cached_user')
     comments_count = serializers.SerializerMethodField()
     likes_count = serializers.SerializerMethodField()
     has_liked = serializers.SerializerMethodField()

--- a/tweets/api/tests.py
+++ b/tweets/api/tests.py
@@ -14,6 +14,7 @@ TWEET_RETRIEVE_API = '/api/tweets/{}/'
 class TweetApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.user1 = self.create_user('user1', 'user1@jiuzhang.com')
         self.tweets1 = [
             self.create_tweet(self.user1)

--- a/tweets/models.py
+++ b/tweets/models.py
@@ -1,9 +1,10 @@
+from accounts.services import UserService
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from likes.models import Like
-from utils.time_helpers import utc_now
 from tweets.constants import TweetPhotoStatus, TWEET_PHOTO_STATUS_CHOICES
+from utils.time_helpers import utc_now
 
 
 class Tweet(models.Model):
@@ -30,6 +31,10 @@ class Tweet(models.Model):
             content_type=ContentType.objects.get_for_model(Tweet),
             object_id=self.id,
         ).order_by('-created_at')
+
+    @property
+    def cached_user(self):
+        return UserService.get_user_through_cache(self.user_id)
 
 
 class TweetPhoto(models.Model):

--- a/tweets/tests.py
+++ b/tweets/tests.py
@@ -6,7 +6,9 @@ from utils.time_helpers import utc_now
 
 
 class TweetTests(TestCase):
+
     def setUp(self):
+        self.clear_cache()
         self.linghu = self.create_user('linghu')
         self.tweet = self.create_tweet(self.linghu, content='Jiuzhang Dafa Hao')
 

--- a/twitter/cache.py
+++ b/twitter/cache.py
@@ -1,1 +1,3 @@
 FOLLOWINGS_PATTERN = 'followings:{user_id}'
+USER_PATTERN = 'user:{user_id}'
+USER_PROFILE_PATTERN = 'userprofile:{user_id}'


### PR DESCRIPTION
1. No migrations
2. **43 tests** to pass
3. Go check a few tweets, followings, user infos etc.
4. You now may need admin account to check http://192.168.64.34:8000/api/users
5. Then run 'memcstat --servers localhost', now you see lots of activites:
<img width="699" alt="Screenshot 2022-11-29 at 2 05 02 AM" src="https://user-images.githubusercontent.com/3407579/204499826-6dce64b5-4680-4b86-9f48-5be6b725275f.png">
<img width="243" alt="Screenshot 2022-11-29 at 2 05 33 AM" src="https://user-images.githubusercontent.com/3407579/204499941-40e6fc8d-0a1a-4594-b700-00c9e19c798f.png">
7. run 'memcdump --servers localhost':
<img width="691" alt="Screenshot 2022-11-29 at 2 06 02 AM" src="https://user-images.githubusercontent.com/3407579/204500031-16e03148-8283-4f1f-b44a-df2c5ba517bd.png">
<img width="107" alt="Screenshot 2022-11-29 at 2 06 17 AM" src="https://user-images.githubusercontent.com/3407579/204500081-9cb5d630-fe49-464f-a082-d040f2a7babf.png">