### PR TITLE
33-cache-tweet-list-in-redis

### DIFF
--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIClient
 from tweets.models import Tweet
 from utils.redis_client import RedisClient
 
+
 class TestCase(DjangoTestCase):
 
     def clear_cache(self):

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -8,6 +8,7 @@ from tweets.api.serializers import (
     TweetSerializerForDetail,
 )
 from tweets.models import Tweet
+from tweets.services import TweetService
 from utils.decorators import required_params
 from utils.paginations import EndlessPagination
 
@@ -42,9 +43,7 @@ class TweetViewSet(viewsets.GenericViewSet):
         # order by created_at desc
         # 这句 SQL 查询会用到 user 和 created_at 的联合索引
         # 单纯的 user 索引是不够的
-        tweets = Tweet.objects.filter(
-            user_id=request.query_params['user_id']
-        ).order_by('-created_at')
+        tweets = TweetService.get_cached_tweets(user_id=request.query_params['user_id'])
         tweets = self.paginate_queryset(tweets)
         serializer = TweetSerializer(
             tweets,

--- a/tweets/listeners.py
+++ b/tweets/listeners.py
@@ -1,0 +1,6 @@
+def push_tweet_to_cache(sender, instance, created, **kwargs):
+    if not created:
+        return
+
+    from tweets.services import TweetService
+    TweetService.push_tweet_to_cache(instance)

--- a/tweets/models.py
+++ b/tweets/models.py
@@ -1,10 +1,10 @@
-from accounts.services import UserService
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.signals import post_save
 from likes.models import Like
 from tweets.constants import TweetPhotoStatus, TWEET_PHOTO_STATUS_CHOICES
+from tweets.listeners import push_tweet_to_cache
 from utils.listeners import invalidate_object_cache
 from utils.memcached_helper import MemcachedHelper
 from utils.time_helpers import utc_now
@@ -80,3 +80,4 @@ class TweetPhoto(models.Model):
 
 
 post_save.connect(invalidate_object_cache, sender=Tweet)
+post_save.connect(push_tweet_to_cache, sender=Tweet)

--- a/tweets/services.py
+++ b/tweets/services.py
@@ -1,4 +1,7 @@
+from tweets.models import Tweet
 from tweets.models import TweetPhoto
+from twitter.cache import USER_TWEETS_PATTERN
+from utils.redis_helper import RedisHelper
 
 
 class TweetService(object):
@@ -15,3 +18,15 @@ class TweetService(object):
             )
             photos.append(photo)
         TweetPhoto.objects.bulk_create(photos)
+
+    @classmethod
+    def get_cached_tweets(cls, user_id):
+        queryset = Tweet.objects.filter(user_id=user_id).order_by('-created_at')
+        key = USER_TWEETS_PATTERN.format(user_id=user_id)
+        return RedisHelper.load_objects(key, queryset)
+
+    @classmethod
+    def push_tweet_to_cache(cls, tweet):
+        queryset = Tweet.objects.filter(user_id=tweet.user_id).order_by('-created_at')
+        key = USER_TWEETS_PATTERN.format(user_id=tweet.user_id)
+        RedisHelper.push_object(key, tweet, queryset)

--- a/tweets/tests.py
+++ b/tweets/tests.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 from testing.testcases import TestCase
 from tweets.constants import TweetPhotoStatus
 from tweets.models import TweetPhoto
+from tweets.services import TweetService
+from twitter.cache import USER_TWEETS_PATTERN
 from utils.redis_client import RedisClient
 from utils.redis_serializers import DjangoModelSerializer
 from utils.time_helpers import utc_now
@@ -51,3 +53,48 @@ class TweetTests(TestCase):
         data = conn.get(f'tweet:{tweet.id}')
         cached_tweet = DjangoModelSerializer.deserialize(data)
         self.assertEqual(tweet, cached_tweet)
+
+
+class TweetServiceTests(TestCase):
+
+    def setUp(self):
+        self.clear_cache()
+        self.linghu = self.create_user('linghu')
+
+    def test_get_user_tweets(self):
+        tweet_ids = []
+        for i in range(3):
+            tweet = self.create_tweet(self.linghu, 'tweet {}'.format(i))
+            tweet_ids.append(tweet.id)
+        tweet_ids = tweet_ids[::-1]
+
+        RedisClient.clear()
+        conn = RedisClient.get_connection()
+
+        # cache miss
+        tweets = TweetService.get_cached_tweets(self.linghu.id)
+        self.assertEqual([t.id for t in tweets], tweet_ids)
+
+        # cache hit
+        tweets = TweetService.get_cached_tweets(self.linghu.id)
+        self.assertEqual([t.id for t in tweets], tweet_ids)
+
+        # cache updated
+        new_tweet = self.create_tweet(self.linghu, 'new tweet')
+        tweets = TweetService.get_cached_tweets(self.linghu.id)
+        tweet_ids.insert(0, new_tweet.id)
+        self.assertEqual([t.id for t in tweets], tweet_ids)
+
+    def test_create_new_tweet_before_get_cached_tweets(self):
+        tweet1 = self.create_tweet(self.linghu, 'tweet1')
+
+        RedisClient.clear()
+        conn = RedisClient.get_connection()
+
+        key = USER_TWEETS_PATTERN.format(user_id=self.linghu.id)
+        self.assertEqual(conn.exists(key), False)
+        tweet2 = self.create_tweet(self.linghu, 'tweet2')
+        self.assertEqual(conn.exists(key), True)
+
+        tweets = TweetService.get_cached_tweets(self.linghu.id)
+        self.assertEqual([t.id for t in tweets], [tweet2.id, tweet1.id])

--- a/twitter/cache.py
+++ b/twitter/cache.py
@@ -1,2 +1,6 @@
+# memcached
 FOLLOWINGS_PATTERN = 'followings:{user_id}'
 USER_PROFILE_PATTERN = 'userprofile:{user_id}'
+
+# redis
+USER_TWEETS_PATTERN = 'user_tweets:{user_id}'

--- a/utils/paginations.py
+++ b/utils/paginations.py
@@ -1,3 +1,4 @@
+from dateutil import parser
 from rest_framework.pagination import BasePagination
 from rest_framework.response import Response
 
@@ -12,7 +13,35 @@ class EndlessPagination(BasePagination):
     def to_html(self):
         pass
 
+    def paginate_ordered_list(self, reverse_ordered_list, request):
+        if 'created_at__gt' in request.query_params:
+            created_at__gt = parser.isoparse(request.query_params['created_at__gt'])
+            objects = []
+            for obj in reverse_ordered_list:
+                if obj.created_at > created_at__gt:
+                    objects.append(obj)
+                else:
+                    break
+            self.has_next_page = False
+            return objects
+
+        index = 0
+        if 'created_at__lt' in request.query_params:
+            created_at__lt = parser.isoparse(request.query_params['created_at__lt'])
+            for index, obj in enumerate(reverse_ordered_list):
+                if obj.created_at < created_at__lt:
+                    break
+            else:
+                # 没找到任何满足条件的 objects, 返回空数组
+                # 注意这个 else 对应的是 for，参见 python 的 for else 语法
+                reverse_ordered_list = []
+        self.has_next_page = len(reverse_ordered_list) > index + self.page_size
+        return reverse_ordered_list[index: index + self.page_size]
+
     def paginate_queryset(self, queryset, request, view=None):
+        if type(queryset) == list:
+            return self.paginate_ordered_list(queryset, request)
+
         if 'created_at__gt' in request.query_params:
             # created_at__gt 用于下拉刷新的时候加载最新的内容进来
             # 为了简便起见，下拉刷新不做翻页机制，直接加载所有更新的数据

--- a/utils/redis_helper.py
+++ b/utils/redis_helper.py
@@ -1,0 +1,48 @@
+from django.conf import settings
+from utils.redis_client import RedisClient
+from utils.redis_serializers import DjangoModelSerializer
+
+
+class RedisHelper:
+
+    @classmethod
+    def _load_objects_to_cache(cls, key, objects):
+        conn = RedisClient.get_connection()
+
+        serialized_list = []
+        for obj in objects:
+            serialized_data = DjangoModelSerializer.serialize(obj)
+            serialized_list.append(serialized_data)
+
+        if serialized_list:
+            conn.rpush(key, *serialized_list)
+            conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
+
+    @classmethod
+    def load_objects(cls, key, queryset):
+        conn = RedisClient.get_connection()
+
+        # 如果在 cache 里存在，则直接拿出来，然后返回
+        if conn.exists(key):
+            serialized_list = conn.lrange(key, 0, -1)
+            objects = []
+            for serialized_data in serialized_list:
+                deserialized_obj = DjangoModelSerializer.deserialize(serialized_data)
+                objects.append(deserialized_obj)
+            return objects
+
+        cls._load_objects_to_cache(key, queryset)
+
+        # 转换为 list 的原因是保持返回类型的统一，因为存在 redis 里的数据是 list 的形式
+        return list(queryset)
+
+    @classmethod
+    def push_object(cls, key, obj, queryset):
+        conn = RedisClient.get_connection()
+        if not conn.exists(key):
+            # 如果 key 不存在，直接从数据库里 load
+            # 就不走单个 push 的方式加到 cache 里了
+            cls._load_objects_to_cache(key, queryset)
+            return
+        serialized_data = DjangoModelSerializer.serialize(obj)
+        conn.lpush(key, serialized_data)

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,6 +1,7 @@
 from testing.testcases import TestCase
 from utils.redis_client import RedisClient
 
+
 class UtilsTests(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
1. no new migrations
2. **48 tests** to pass
3. Create and view tweets etc.
4. Can see more in memcached, now there's Tweet related cache
<img width="691" alt="Screenshot 2022-11-29 at 3 04 34 AM" src="https://user-images.githubusercontent.com/3407579/204513150-99782419-dcfa-4333-9212-c0874f7b276b.png">
5. Will add more details about redis later